### PR TITLE
Refactor binary questions to allow arbitrary values for labels

### DIFF
--- a/app/actions/answer.ts
+++ b/app/actions/answer.ts
@@ -62,10 +62,7 @@ export async function saveDeck(request: SaveQuestionRequest[], deckId: number) {
     );
     const isOptionSelected = qo.id === answerForQuestion?.questionOptionId;
 
-    if (
-      qo.question.type === QuestionType.TrueFalse ||
-      qo.question.type === QuestionType.YesNo
-    ) {
+    if (qo.question.type === QuestionType.BinaryQuestion) {
       const isYesOrTrueOption = qo.option === "Yes" || qo.option === "True";
       return {
         percentage: isYesOrTrueOption
@@ -155,10 +152,7 @@ export async function saveQuestion(request: SaveQuestionRequest) {
   const questionAnswers = questionOptions.map((qo) => {
     const isOptionSelected = qo.id === request?.questionOptionId;
 
-    if (
-      qo.question.type === QuestionType.TrueFalse ||
-      qo.question.type === QuestionType.YesNo
-    ) {
+    if (qo.question.type === QuestionType.BinaryQuestion) {
       const isYesOrTrueOption = qo.option === "Yes" || qo.option === "True";
       return {
         percentage: isYesOrTrueOption

--- a/app/actions/question.ts
+++ b/app/actions/question.ts
@@ -130,18 +130,21 @@ export async function handleUpsertingQuestionOptionsConcurrently(
   questionOptions: {
     option: string;
     id?: number | undefined;
-    isTrue?: boolean | undefined;
+    isCorrect?: boolean | undefined;
+    isLeft?: boolean | undefined;
   }[],
 ) {
   const questionOptionUpsertPromiseArray = questionOptions.map((qo) => {
     return tx.questionOption.upsert({
       create: {
-        isTrue: qo.isTrue,
+        isCorrect: qo.isCorrect,
         option: qo.option,
+        isLeft: qo.isLeft,
         questionId: questionId,
       },
       update: {
-        isTrue: qo.isTrue,
+        isCorrect: qo.isCorrect,
+        isLeft: qo.isLeft,
         option: qo.option,
       },
       where: {

--- a/app/components/AnsweredQuestionContent/AnsweredQuestionContent.tsx
+++ b/app/components/AnsweredQuestionContent/AnsweredQuestionContent.tsx
@@ -33,7 +33,7 @@ export const AnsweredQuestionContent = ({
   );
 
   const isFirstOrderQuestionCorrect = element.questionOptions.some(
-    (qo) => qo.isTrue && qo.questionAnswers.some((qa) => qa.selected),
+    (qo) => qo.isCorrect && qo.questionAnswers.some((qa) => qa.selected),
   );
   const handleBinary = useCallback(() => {
     const binaryQuestionResults = mapQuestionToBinaryQuestionAnswer(element);
@@ -54,13 +54,9 @@ export const AnsweredQuestionContent = ({
       case "MultiChoice": {
         return <MultipleChoiceAnsweredContent {...baseProps} />;
       }
-      case "TrueFalse": {
+      case "BinaryQuestion": {
         handleBinary();
         return <BooleanAnsweredContent {...baseProps} />;
-      }
-      case "YesNo": {
-        handleBinary();
-        return <BooleanAnsweredContent {...baseProps} isYesNo />;
       }
     }
   }, [handleBinary, baseProps, element.type]);

--- a/app/components/BooleanAnsweredContent/BooleanAnsweredContent.tsx
+++ b/app/components/BooleanAnsweredContent/BooleanAnsweredContent.tsx
@@ -3,7 +3,8 @@ import { TrueFalseScale } from "../TrueFalseScale/TrueFalseScale";
 type BooleanAnsweredContentProps = {
   questionOptions: {
     id: number;
-    isTrue: boolean;
+    isCorrect: boolean;
+    isLeft: boolean;
     option: string;
     questionAnswers: {
       percentage: number | null;
@@ -12,36 +13,34 @@ type BooleanAnsweredContentProps = {
     }[];
   }[];
   avatarSrc?: string;
-  isYesNo?: boolean;
 };
 
 export function BooleanAnsweredContent({
   questionOptions,
   avatarSrc,
-  isYesNo = false,
 }: BooleanAnsweredContentProps) {
-  const trueOption = questionOptions.find(
-    (qo) => qo.option === "True" || qo.option === "Yes",
-  );
-  const ratioTrue = trueOption?.questionAnswers[0]?.percentageResult;
-  const ratioSelectedTrue = trueOption?.questionAnswers[0]?.percentage;
-  const isTrueTrue = trueOption?.isTrue;
-  const isTrueSelected = trueOption?.questionAnswers[0]?.selected;
+  const leftOption = questionOptions.find((qo) => qo.isLeft);
+  const ratioLeft = leftOption?.questionAnswers[0]?.percentageResult;
+  const ratioSelectedTrue = leftOption?.questionAnswers[0]?.percentage;
+  const isTrueCorrect = leftOption?.isCorrect;
+  const isTrueSelected = leftOption?.questionAnswers[0]?.selected;
+  const labelLeft = leftOption?.option ?? "";
+  const labelRight = questionOptions.find((qo) => !qo.isLeft)?.option ?? "";
 
   return (
     <div className="w-full">
       <div className="mb-2">
         <TrueFalseScale
-          ratioTrue={ratioTrue}
+          ratioLeft={ratioLeft}
           valueSelected={ratioSelectedTrue}
           avatarSrc={avatarSrc}
-          labelTrue={isYesNo ? "Yes" : undefined}
-          labelFalse={isYesNo ? "No" : undefined}
+          labelLeft={labelLeft}
+          labelRight={labelRight}
           progressColor={
-            isTrueTrue ? "#6DECAF" : isTrueSelected ? "#ED6A5A" : undefined
+            isTrueCorrect ? "#6DECAF" : isTrueSelected ? "#ED6A5A" : undefined
           }
           bgColor={
-            !isTrueTrue ? "#6DECAF" : !isTrueSelected ? "#2c1e1d" : undefined
+            !isTrueCorrect ? "#6DECAF" : !isTrueSelected ? "#2c1e1d" : undefined
           }
         />
       </div>

--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -18,6 +18,7 @@ import { QuestionCardContent } from "../QuestionCardContent/QuestionCardContent"
 export type Option = {
   id: number;
   option: string;
+  isLeft: boolean;
 };
 
 export type Question = {
@@ -45,7 +46,7 @@ const getDueAt = (questions: Question[], index: number): Date => {
 export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
   const questionsRef = useRef<HTMLDivElement>(null);
   const [dueAt, setDueAt] = useState<Date>(getDueAt(questions, 0));
-  const [rerenderAction, setRerednerAction] = useState(true);
+  const [rerenderAction, setRerenderAction] = useState(true);
   const [deckResponse, setDeckResponse] = useState<SaveQuestionRequest[]>([]);
   const [currentQuestionStep, setCurrentQuestionStep] = useState<QuestionStep>(
     QuestionStep.AnswerQuestion,
@@ -68,12 +69,12 @@ export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
     }
     setCurrentQuestionIndex((index) => index + 1);
     setCurrentQuestionStep(QuestionStep.AnswerQuestion);
-    setRerednerAction(false);
+    setRerenderAction(false);
     setOptionPercentage(50);
     setCurrentOptionSelected(undefined);
     generateRandom();
     setTimeout(() => {
-      setRerednerAction(true);
+      setRerenderAction(true);
     });
     setTimeout(() => {
       if (questionsRef.current) {
@@ -84,7 +85,7 @@ export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
     currentQuestionIndex,
     setCurrentQuestionIndex,
     setCurrentQuestionStep,
-    setRerednerAction,
+    setRerenderAction,
     generateRandom,
     setCurrentOptionSelected,
     questionsRef.current,
@@ -100,11 +101,11 @@ export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
     handleNextIndex();
   }, [question, handleNextIndex, setDeckResponse]);
 
-  const onQuesitonActionClick = useCallback(
+  const onQuestionActionClick = useCallback(
     (number: number | undefined) => {
       if (
         currentQuestionStep === QuestionStep.AnswerQuestion &&
-        (question.type === "TrueFalse" || question.type === "YesNo")
+        question.type === "BinaryQuestion"
       ) {
         setDeckResponse((prev) => [
           ...prev,
@@ -137,17 +138,17 @@ export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
 
       if (
         currentQuestionStep === QuestionStep.PickPercentage &&
-        (question.type === "TrueFalse" || question.type === "YesNo")
+        question.type === "BinaryQuestion"
       ) {
         setDeckResponse((prev) => {
-          const newResposnes = [...prev];
-          const response = newResposnes.pop();
+          const newResponses = [...prev];
+          const response = newResponses.pop();
           if (response) {
             response.percentageGiven = number ?? 0;
-            newResposnes.push(response);
+            newResponses.push(response);
           }
 
-          return newResposnes;
+          return newResponses;
         });
       }
 
@@ -156,16 +157,16 @@ export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
         question.type === "MultiChoice"
       ) {
         setDeckResponse((prev) => {
-          const newResposnes = [...prev];
-          const response = newResposnes.pop();
+          const newResponses = [...prev];
+          const response = newResponses.pop();
           if (response) {
             response.percentageGiven = optionPercentage;
             response.percentageGivenForAnswerId =
               question.questionOptions[random]?.id;
-            newResposnes.push(response);
+            newResponses.push(response);
           }
 
-          return newResposnes;
+          return newResponses;
         });
       }
 
@@ -262,7 +263,7 @@ export function Deck({ questions, browseHomeUrl, deckId }: DeckProps) {
       <div className="pt-2">
         {rerenderAction && (
           <QuestionAction
-            onButtonClick={onQuesitonActionClick}
+            onButtonClick={onQuestionActionClick}
             type={question.type}
             step={currentQuestionStep}
             questionOptions={question.questionOptions}

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -146,23 +146,29 @@ export default function DeckForm({ deck, tags, action }: DeckFormProps) {
                           {...register(
                             `questions.${questionIndex}.questionOptions.${optionIndex}.option`,
                           )}
-                          disabled={
-                            watch(`questions.${questionIndex}.type`) ===
-                              QuestionType.YesNo ||
-                            watch(`questions.${questionIndex}.type`) ===
-                              QuestionType.TrueFalse
-                          }
                         />
                       </div>
-                      <div className="w-24 flex justify-center items-center gap-2">
-                        <div>is true?</div>
+                      <div className="w-28 flex justify-center items-center gap-2">
+                        <div>is correct?</div>
                         <input
                           type="checkbox"
                           {...register(
-                            `questions.${questionIndex}.questionOptions.${optionIndex}.isTrue`,
+                            `questions.${questionIndex}.questionOptions.${optionIndex}.isCorrect`,
                           )}
                         />
                       </div>
+                      {watch(`questions.${questionIndex}.type`) ===
+                        QuestionType.BinaryQuestion && (
+                        <div className="w-24 flex justify-center items-center gap-2">
+                          <div>is left?</div>
+                          <input
+                            type="checkbox"
+                            {...register(
+                              `questions.${questionIndex}.questionOptions.${optionIndex}.isLeft`,
+                            )}
+                          />
+                        </div>
+                      )}
                     </div>
                     <div className="text-red">
                       {errors.questions &&

--- a/app/components/MultipleChoiceAnsweredContent/MultipleChoiceAnsweredContent.tsx
+++ b/app/components/MultipleChoiceAnsweredContent/MultipleChoiceAnsweredContent.tsx
@@ -3,7 +3,7 @@ import { AnswerResult } from "../AnswerResult/AnswerResult";
 type MultipleChoiceAnsweredContentProps = {
   questionOptions: {
     id: number;
-    isTrue: boolean;
+    isCorrect: boolean;
     option: string;
     questionAnswers: {
       percentage: number | null;
@@ -28,7 +28,7 @@ export function MultipleChoiceAnsweredContent({
             avatarSrc={avatarSrc}
             answerText={qo.option}
             progressBarClassName={
-              qo.isTrue
+              qo.isCorrect
                 ? "!bg-aqua"
                 : qo.questionAnswers[0].selected
                   ? "!bg-warning"

--- a/app/components/Question/Question.tsx
+++ b/app/components/Question/Question.tsx
@@ -21,6 +21,7 @@ export const NUMBER_OF_STEPS_PER_QUESTION = 2;
 type Option = {
   id: number;
   option: string;
+  isLeft: boolean;
 };
 
 type Question = {
@@ -75,11 +76,11 @@ export function Question({ question, returnUrl }: QuestionProps) {
     [setCurrentQuestionStep, answerState],
   );
 
-  const onQuesitonActionClick = useCallback(
+  const onQuestionActionClick = useCallback(
     (number: number | undefined) => {
       if (
         currentQuestionStep === QuestionStep.AnswerQuestion &&
-        (question.type === "TrueFalse" || question.type === "YesNo")
+        question.type === "BinaryQuestion"
       ) {
         setAnswerState({ questionId: question.id, questionOptionId: number });
         setCurrentQuestionStep(QuestionStep.PickPercentage);
@@ -106,7 +107,7 @@ export function Question({ question, returnUrl }: QuestionProps) {
 
       if (
         currentQuestionStep === QuestionStep.PickPercentage &&
-        (question.type === "TrueFalse" || question.type === "YesNo")
+        question.type === "BinaryQuestion"
       ) {
         handleSaveQuestion({
           ...answerState,
@@ -166,7 +167,7 @@ export function Question({ question, returnUrl }: QuestionProps) {
 
       <div className="pt-2">
         <QuestionAction
-          onButtonClick={onQuesitonActionClick}
+          onButtonClick={onQuestionActionClick}
           type={question.type}
           step={currentQuestionStep || QuestionStep.PickPercentage}
           questionOptions={question.questionOptions}

--- a/app/components/QuestionAction/QuestionAction.tsx
+++ b/app/components/QuestionAction/QuestionAction.tsx
@@ -8,6 +8,7 @@ import { TrueFalseScale } from "../TrueFalseScale/TrueFalseScale";
 type QuestionOption = {
   id: number;
   option: string;
+  isLeft: boolean;
 };
 
 type QuestionActionProps = {
@@ -27,10 +28,7 @@ export function QuestionAction({
 }: QuestionActionProps) {
   const [scale, setScale] = useState(50);
 
-  if (
-    (type === "TrueFalse" || type === "YesNo") &&
-    step === QuestionStep.AnswerQuestion
-  ) {
+  if (type === "BinaryQuestion" && step === QuestionStep.AnswerQuestion) {
     return (
       <div className="text-center text-white font-semibold">
         <div className="text-md mb-4">
@@ -53,9 +51,12 @@ export function QuestionAction({
   }
 
   if (
-    (type === "TrueFalse" || type === "YesNo") &&
-    step === QuestionStep.PickPercentage
+    type === "BinaryQuestion" &&
+    step === QuestionStep.PickPercentage &&
+    questionOptions
   ) {
+    const optionLeft = questionOptions.find((qo) => qo.isLeft)?.option ?? "";
+    const optionRight = questionOptions.find((qo) => !qo.isLeft)?.option ?? "";
     return (
       <div className="text-white font-semibold">
         <div className="text-center  text-md mb-4">
@@ -64,11 +65,11 @@ export function QuestionAction({
         <div className="flex gap-2 items-center">
           <div className="!w-[85%]">
             <TrueFalseScale
-              ratioTrue={scale}
+              ratioLeft={scale}
               progressBarClassName="h-[36px] rounded-md"
               handleRatioChange={setScale}
-              labelTrue={type === "YesNo" ? "Yes" : undefined}
-              labelFalse={type === "YesNo" ? "No" : undefined}
+              labelLeft={optionLeft}
+              labelRight={optionRight}
             />
           </div>
           <Button

--- a/app/components/QuestionCardContent/QuestionCardContent.tsx
+++ b/app/components/QuestionCardContent/QuestionCardContent.tsx
@@ -36,7 +36,7 @@ export function QuestionCardContent({
     onPercentageChange: onPercentageChanged,
   });
 
-  if (type === "TrueFalse") {
+  if (type === "BinaryQuestion") {
     return <></>;
   }
 

--- a/app/components/QuestionForm/QuestionForm.tsx
+++ b/app/components/QuestionForm/QuestionForm.tsx
@@ -22,22 +22,17 @@ type QuestionFormProps = {
 
 export const getDefaultOptions = (type: QuestionType) => {
   switch (type) {
-    case QuestionType.YesNo:
+    case QuestionType.BinaryQuestion:
       return [
-        { option: "Yes", isTrue: false },
-        { option: "No", isTrue: false },
-      ];
-    case QuestionType.TrueFalse:
-      return [
-        { option: "True", isTrue: false },
-        { option: "False", isTrue: false },
+        { option: "", isCorrect: false, isLeft: true },
+        { option: "", isCorrect: false, isLeft: false },
       ];
     default:
       return [
-        { option: "", isTrue: false },
-        { option: "", isTrue: false },
-        { option: "", isTrue: false },
-        { option: "", isTrue: false },
+        { option: "", isCorrect: false, isLeft: false },
+        { option: "", isCorrect: false, isLeft: false },
+        { option: "", isCorrect: false, isLeft: false },
+        { option: "", isCorrect: false, isLeft: false },
       ];
   }
 };
@@ -120,19 +115,24 @@ export default function QuestionForm({
                   <TextInput
                     variant="secondary"
                     {...register(`questionOptions.${index}.option`)}
-                    disabled={
-                      questionType === QuestionType.YesNo ||
-                      questionType === QuestionType.TrueFalse
-                    }
                   />
                 </div>
-                <div className="w-24 flex justify-center items-center gap-2">
-                  <div>is true?</div>
+                <div className="w-28 flex justify-center items-center gap-2">
+                  <div>is correct?</div>
                   <input
                     type="checkbox"
-                    {...register(`questionOptions.${index}.isTrue`)}
+                    {...register(`questionOptions.${index}.isCorrect`)}
                   />
                 </div>
+                {watch("type") === QuestionType.BinaryQuestion && (
+                  <div className="w-24 flex justify-center items-center gap-2">
+                    <div>is left?</div>
+                    <input
+                      type="checkbox"
+                      {...register(`questionOptions.${index}.isLeft`)}
+                    />
+                  </div>
+                )}
               </div>
               <div className="text-red">
                 {errors.questionOptions &&

--- a/app/components/RadioInput/RadioInput.tsx
+++ b/app/components/RadioInput/RadioInput.tsx
@@ -18,6 +18,7 @@ export function RadioInput({
       {options.map((o, index) => (
         <div key={index} className="[&:not(:first-of-type)]:mt-2">
           <button
+            type="button"
             onClick={() => onOptionSelected(o.value)}
             className="flex items-center space-x-2"
           >

--- a/app/components/TrueFalseScale/TrueFalseScale.tsx
+++ b/app/components/TrueFalseScale/TrueFalseScale.tsx
@@ -5,25 +5,25 @@ import { Avatar } from "../Avatar/Avatar";
 import { ProgressBar } from "../ProgressBar/ProgressBar";
 
 type TrueFalseScaleProps = {
-  ratioTrue?: number | null;
+  ratioLeft?: number | null;
   valueSelected?: number | null;
   avatarSrc?: string;
   progressBarClassName?: string;
   handleRatioChange?: (percentage: number) => void;
-  labelTrue?: string;
-  labelFalse?: string;
+  labelLeft: string;
+  labelRight: string;
   progressColor?: string;
   bgColor?: string;
 };
 
 export function TrueFalseScale({
-  ratioTrue,
+  ratioLeft,
   valueSelected,
   avatarSrc,
   progressBarClassName,
   handleRatioChange,
-  labelTrue = "True",
-  labelFalse = "False",
+  labelLeft,
+  labelRight,
   progressColor = "#8872A5",
   bgColor = "#CFC5F7",
 }: TrueFalseScaleProps) {
@@ -33,7 +33,7 @@ export function TrueFalseScale({
       : `${valueSelected}%`
     : undefined;
   const { handlePercentageChange } = useSteppingChange({
-    percentage: ratioTrue ?? 0,
+    percentage: ratioLeft ?? 0,
     onPercentageChange: handleRatioChange,
   });
 
@@ -47,20 +47,20 @@ export function TrueFalseScale({
       {!!handleRatioChange && isVisibleBackdrop && (
         <div className="absolute px-5 py-4 bg-pink right-0 -top-4 -translate-y-full z-[9999] rounded-xl flex gap-5">
           <p className="text-[#0d0d0d7d] font-normal">
-            {labelTrue.substring(0, 1)}{" "}
-            <span className="text-[#0D0D0D] font-semibold">{ratioTrue}%</span>
+            {labelLeft}{" "}
+            <span className="text-[#0D0D0D] font-semibold">{ratioLeft}%</span>
           </p>
           <p className="text-[#0d0d0d7d] font-normal">
-            {labelFalse.substring(0, 1)}{" "}
+            {labelRight}{" "}
             <span className="text-[#0D0D0D] font-semibold">
-              {100 - (ratioTrue ?? 0)}%
+              {100 - (ratioLeft ?? 0)}%
             </span>
           </p>
         </div>
       )}
       <ProgressBar
         percentage={
-          ratioTrue === undefined || ratioTrue === null ? 100 : ratioTrue
+          ratioLeft === undefined || ratioLeft === null ? 100 : ratioLeft
         }
         progressColor={progressColor}
         bgColor={bgColor}
@@ -80,13 +80,13 @@ export function TrueFalseScale({
       )}
       <div className="flex justify-between text-white font-sora text-base font-semibold mt-2 z-30 relative">
         <span>
-          {labelTrue} {ratioTrue ?? "0"}%
+          {labelLeft} {ratioLeft ?? "0"}%
         </span>
         <span>
-          {labelFalse}{" "}
-          {ratioTrue === undefined || ratioTrue === null
+          {labelRight}{" "}
+          {ratioLeft === undefined || ratioLeft === null
             ? "0"
-            : 100 - ratioTrue}
+            : 100 - ratioLeft}
           %
         </span>
       </div>

--- a/app/queries/deck.ts
+++ b/app/queries/deck.ts
@@ -154,6 +154,7 @@ const mapQuestionFromDeck = (
     questionOptions: dq.question.questionOptions.map((qo) => ({
       id: qo.id,
       option: qo.option,
+      isLeft: qo.isLeft,
     })),
     questionTags: dq.question.questionTags,
     deckRevealAtDate: deck.revealAtDate,
@@ -459,8 +460,8 @@ export async function getHomeFeedDecks({
   if (!areRevealed) {
     decks?.forEach((d) => {
       d.deckQuestions?.forEach((dq) => {
-        dq.question?.questionOptions?.forEach((qo: { isTrue?: boolean }) => {
-          delete qo.isTrue;
+        dq.question?.questionOptions?.forEach((qo: { isCorrect?: boolean }) => {
+          delete qo.isCorrect;
         });
       });
     });

--- a/app/queries/question.ts
+++ b/app/queries/question.ts
@@ -67,6 +67,7 @@ const mapToViewModelQuestion = (
   questionOptions: question.questionOptions.map((qo) => ({
     id: qo.id,
     option: qo.option,
+    isLeft: qo.isLeft,
   })),
   questionTags: question.questionTags,
   type: question.type,

--- a/app/schemas/deck.ts
+++ b/app/schemas/deck.ts
@@ -7,7 +7,7 @@ export const deckSchema = z.object({
   imageUrl: z.string().nullable(),
   tagIds: z.number().array().default([]),
   revealToken: z.nativeEnum(Token),
-  date: z.date().nullable(),
+  date: z.date().nullable().optional(),
   revealTokenAmount: z.number().min(0),
   revealAtDate: z.date().nullable(),
   revealAtAnswerCount: z.number().min(0).nullable(),
@@ -26,7 +26,8 @@ export const deckSchema = z.object({
         .object({
           id: z.number().optional(),
           option: z.string().min(1),
-          isTrue: z.boolean().optional(),
+          isCorrect: z.boolean().optional(),
+          isLeft: z.boolean(),
         })
         .array(),
     })

--- a/app/schemas/question.ts
+++ b/app/schemas/question.ts
@@ -19,7 +19,8 @@ export const questionSchema = z.object({
     .object({
       id: z.number().optional(),
       option: z.string().min(1),
-      isTrue: z.boolean().optional(),
+      isCorrect: z.boolean().optional(),
+      isLeft: z.boolean(),
     })
     .array(),
 });

--- a/app/utils/question.ts
+++ b/app/utils/question.ts
@@ -5,7 +5,8 @@ export type DeckQuestionIncludes = Question & {
   answerCount?: number;
   questionOptions: {
     id: number;
-    isTrue: boolean;
+    isCorrect: boolean;
+    isLeft: boolean;
     questionAnswers: Array<
       QuestionAnswer & {
         percentageResult?: number | null;
@@ -157,7 +158,12 @@ export const populateAnswerCount = (
   }
 
   questions.forEach((q) => {
-    q.answerCount = q.questionOptions[0].questionAnswers.length;
+    if (q.questionOptions && q.questionOptions.length > 0) {
+      q.answerCount = q.questionOptions[0].questionAnswers.length;
+      return;
+    }
+
+    q.answerCount = 0;
   });
 
   if ((element as Deck).deck) {
@@ -208,8 +214,8 @@ export const handleQuestionMappingForFeed = (
 
   if (!areRevealed) {
     questions?.forEach((q) => {
-      q.questionOptions?.forEach((qo: { isTrue?: boolean }) => {
-        delete qo.isTrue;
+      q.questionOptions?.forEach((qo: { isCorrect?: boolean }) => {
+        delete qo.isCorrect;
       });
     });
   }
@@ -223,11 +229,11 @@ export const handleQuestionMappingForFeed = (
           const correctQuestion = getCorrectBinaryQuestion(a, b);
           q.questionOptions.forEach((qo) => {
             if (qo.id === correctQuestion?.optionId) {
-              qo.isTrue = true;
+              qo.isCorrect = true;
               return;
             }
 
-            qo.isTrue = false;
+            qo.isCorrect = false;
           });
         }
       }

--- a/deck.md
+++ b/deck.md
@@ -1,28 +1,27 @@
 
 ```sql
--- Insert a Deck and return its ID
 WITH inserted_deck AS (
-  INSERT INTO "Deck" ("deck", "date")
-  VALUES ('Sample Deck', NOW() + (random() * 4) * INTERVAL '1 hour')
+  INSERT INTO "Deck" ("deck", "date", "revealAtDate")
+  VALUES ('Sample Deck', NOW() + (random() * 4) * INTERVAL '1 hour', NOW() + INTERVAL '1 days')
   RETURNING id
 ), inserted_questions AS (
   -- Insert Questions and return their IDs
-  INSERT INTO "Question" ("question", "type", "revealToken", "revealTokenAmount")
+  INSERT INTO "Question" ("question", "type", "revealToken", "revealTokenAmount", "revealAtDate", "durationMiliseconds")
   VALUES 
-    ('Is the sky blue?', 'TrueFalse', 'Bonk', 0),
-    ('Do fish fly?', 'TrueFalse', 'Bonk', 0),
-    ('Is water wet?', 'TrueFalse', 'Bonk', 0),
-    ('Can dogs speak English?', 'TrueFalse', 'Bonk', 0)
+    ('Is the sky blue?', 'BinaryQuestion', 'Bonk', 0, NOW() + INTERVAL '1 days', 60000),
+    ('Do fish fly?', 'BinaryQuestion', 'Bonk', 0, NOW() + INTERVAL '1 days', 60000),
+    ('Is water wet?', 'BinaryQuestion', 'Bonk', 0, NOW() + INTERVAL '1 days', 60000),
+    ('Can dogs speak English?', 'BinaryQuestion', 'Bonk', 0, NOW() + INTERVAL '1 days', 60000)
   RETURNING id AS question_id
 ), inserted_options AS (
   -- For each inserted question, insert two options
-  INSERT INTO "QuestionOption" ("option", "isTrue", "questionId")
-  SELECT opt.option, opt.isTrue, iq.question_id
+  INSERT INTO "QuestionOption" ("option", "isCorrect", "isLeft", "questionId")
+  SELECT opt.option, opt.isCorrect, opt.isLeft, iq.question_id
   FROM inserted_questions iq
   CROSS JOIN LATERAL (VALUES 
-    ('True', TRUE), 
-    ('False', FALSE)
-  ) AS opt(option, isTrue)
+    ('True', true, true), 
+    ('False', false, false)
+  ) AS opt(option, isCorrect, isLeft)
 ), cross_join AS (
   -- Cross join to prepare rows for the DeckQuestion table
   SELECT d.id AS deck_id, q.question_id

--- a/prisma/migrations/20240425165519_rename_is_true_question_option/migration.sql
+++ b/prisma/migrations/20240425165519_rename_is_true_question_option/migration.sql
@@ -1,0 +1,12 @@
+ALTER TABLE
+  "QuestionOption"
+ADD
+  COLUMN "isCorrect" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE
+  "QuestionOption"
+SET
+  "isCorrect" = "isTrue";
+
+ALTER TABLE
+  "QuestionOption" DROP COLUMN "isTrue";

--- a/prisma/migrations/20240426152846_refactor_binary_questions/migration.sql
+++ b/prisma/migrations/20240426152846_refactor_binary_questions/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - The values [TrueFalse,YesNo] on the enum `QuestionType` will be removed. If these variants are still used in the database, this will fail.
+
+*/
+-- AlterEnum
+BEGIN;
+CREATE TYPE "QuestionType_new" AS ENUM ('BinaryQuestion', 'MultiChoice');
+ALTER TABLE "Question" ALTER COLUMN "type" TYPE "QuestionType_new" USING ("type"::text::"QuestionType_new");
+ALTER TYPE "QuestionType" RENAME TO "QuestionType_old";
+ALTER TYPE "QuestionType_new" RENAME TO "QuestionType";
+DROP TYPE "QuestionType_old";
+COMMIT;
+
+-- AlterTable
+ALTER TABLE "QuestionOption" ADD COLUMN     "isLeft" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,7 +62,8 @@ model Question {
 model QuestionOption {
   id              Int              @id @default(autoincrement())
   option          String
-  isTrue          Boolean          @default(false)
+  isCorrect       Boolean          @default(false)
+  isLeft          Boolean          @default(false)
   createdAt       DateTime         @default(now())
   updatedAt       DateTime         @default(now()) @updatedAt
   questionId      Int
@@ -159,8 +160,7 @@ model FungibleAssetBalance {
 }
 
 enum QuestionType {
-  TrueFalse
-  YesNo
+  BinaryQuestion
   MultiChoice
 }
 

--- a/seed.md
+++ b/seed.md
@@ -4,13 +4,13 @@ Seed the DB with sample questions.
 
 ```sql
 INSERT INTO "Question" ("question", "type", "revealToken", "revealTokenAmount")
-VALUES ('Is Paris the capital of France?', 'YesNo', 'Bonk', 0);
+VALUES ('Is Paris the capital of France?', 'BinaryQuestion', 'Bonk', 0);
 
 -- Option 1: Yes (correct)
-INSERT INTO "QuestionOption" ("option", "isTrue", "questionId")
+INSERT INTO "QuestionOption" ("option", "isCorrect", "questionId")
 VALUES ('Yes', TRUE, 1);
 
 -- Option 2: No (incorrect)
-INSERT INTO "QuestionOption" ("option", "isTrue", "questionId")
+INSERT INTO "QuestionOption" ("option", "isCorrect", "questionId")
 VALUES ('No', FALSE, 1);
 ```

--- a/stories/BooleanAnsweredContent.stories.tsx
+++ b/stories/BooleanAnsweredContent.stories.tsx
@@ -28,7 +28,8 @@ export const TrueFalse: Story = {
       {
         id: 1,
         option: "True",
-        isTrue: false,
+        isCorrect: false,
+        isLeft: true,
         questionAnswers: [
           {
             percentage: 40,
@@ -40,7 +41,8 @@ export const TrueFalse: Story = {
       {
         id: 2,
         option: "False",
-        isTrue: false,
+        isCorrect: false,
+        isLeft: false,
         questionAnswers: [
           {
             percentage: null,
@@ -59,7 +61,8 @@ export const YesNo: Story = {
       {
         id: 1,
         option: "Yes",
-        isTrue: false,
+        isCorrect: false,
+        isLeft: true,
         questionAnswers: [
           {
             percentage: 40,
@@ -71,7 +74,8 @@ export const YesNo: Story = {
       {
         id: 2,
         option: "No",
-        isTrue: false,
+        isCorrect: false,
+        isLeft: false,
         questionAnswers: [
           {
             percentage: null,

--- a/stories/Deck.stories.tsx
+++ b/stories/Deck.stories.tsx
@@ -1,17 +1,18 @@
+import { QuestionType } from "@prisma/client";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Deck } from "../app/components/Deck/Deck";
 import { ONE_MINUTE_IN_MILISECONDS } from "../app/utils/dateUtils";
-import { QuestionType } from "@prisma/client";
 
 const questionBase = {
-  type: QuestionType.TrueFalse,
+  type: QuestionType.BinaryQuestion,
   durationMiliseconds: ONE_MINUTE_IN_MILISECONDS / 4,
   questionOptions: [
     {
       id: 1,
       option: "False",
+      isLeft: false,
     },
-    { id: 2, option: "True" },
+    { id: 2, option: "True", isLeft: true },
   ],
   questionTags: [
     { id: 1, tag: "Defi" },
@@ -43,10 +44,10 @@ const meta = {
         ...questionBase,
         type: QuestionType.MultiChoice,
         questionOptions: [
-          { id: 1, option: "Answer" },
-          { id: 2, option: "Answer" },
-          { id: 3, option: "Answer" },
-          { id: 4, option: "Answer" },
+          { id: 1, option: "Answer", isLeft: false },
+          { id: 2, option: "Answer", isLeft: false },
+          { id: 3, option: "Answer", isLeft: false },
+          { id: 4, option: "Answer", isLeft: false },
         ],
         id: 2,
         question:

--- a/stories/MultipleChoiceAnsweredContent.stories.tsx
+++ b/stories/MultipleChoiceAnsweredContent.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
       {
         id: 1,
         option: "Option 1",
-        isTrue: false,
+        isCorrect: false,
         questionAnswers: [
           {
             percentage: null,
@@ -25,7 +25,7 @@ const meta = {
       {
         id: 2,
         option: "Option 2",
-        isTrue: false,
+        isCorrect: false,
         questionAnswers: [
           {
             percentage: null,
@@ -37,7 +37,7 @@ const meta = {
       {
         id: 3,
         option: "Option 3",
-        isTrue: false,
+        isCorrect: false,
         questionAnswers: [
           {
             percentage: 30,
@@ -48,7 +48,7 @@ const meta = {
       },
       {
         id: 4,
-        isTrue: false,
+        isCorrect: false,
         option: "Option 4",
         questionAnswers: [
           {

--- a/stories/Question.stories.tsx
+++ b/stories/Question.stories.tsx
@@ -1,7 +1,7 @@
+import { QuestionType } from "@prisma/client";
 import type { Meta, StoryObj } from "@storybook/react";
 import { Question } from "../app/components/Question/Question";
 import { ONE_MINUTE_IN_MILISECONDS } from "../app/utils/dateUtils";
-import { QuestionType } from "@prisma/client";
 
 const questionBase = {
   id: 1,
@@ -39,13 +39,14 @@ export const TrueFale: Story = {
   args: {
     question: {
       ...questionBase,
-      type: QuestionType.TrueFalse,
+      type: QuestionType.BinaryQuestion,
       questionOptions: [
         {
           id: 1,
           option: "False",
+          isLeft: false,
         },
-        { id: 2, option: "True" },
+        { id: 2, option: "True", isLeft: true },
       ],
       question:
         "The best way to secure your assets is to use a hardware wallet.",
@@ -60,10 +61,10 @@ export const MultipleChoice: Story = {
       ...questionBase,
       type: QuestionType.MultiChoice,
       questionOptions: [
-        { id: 1, option: "Answer" },
-        { id: 2, option: "Answer" },
-        { id: 3, option: "Answer" },
-        { id: 4, option: "Answer" },
+        { id: 1, option: "Answer", isLeft: false },
+        { id: 2, option: "Answer", isLeft: false },
+        { id: 3, option: "Answer", isLeft: false },
+        { id: 4, option: "Answer", isLeft: false },
       ],
       question:
         "The best way to secure your assets is to use a software wallet.",

--- a/stories/QuestionAccordion.stories.tsx
+++ b/stories/QuestionAccordion.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { QuestionAccordion } from "../app/components/QuestionAccordion/QuestionAccordion";
 import { fn } from "@storybook/test";
 import dayjs from "dayjs";
 import { Button } from "../app/components/Button/Button";
+import { QuestionAccordion } from "../app/components/QuestionAccordion/QuestionAccordion";
 import { TrueFalseScale } from "../app/components/TrueFalseScale/TrueFalseScale";
 
 const meta = {
@@ -33,7 +33,9 @@ export const Open: Story = {
     question: "The best way to secure your assets is to use a hardware wallet.",
     isCollapsed: false,
     revealedAt: dayjs().add(-2, "day").toDate(),
-    children: <TrueFalseScale ratioTrue={20} />,
+    children: (
+      <TrueFalseScale ratioLeft={20} labelLeft="True" labelRight="False" />
+    ),
     actionChild: (
       <Button variant="white" className="!rounded-full">
         Reveal Results

--- a/stories/QuestionAction.stories.tsx
+++ b/stories/QuestionAction.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { QuestionAction } from "../app/components/QuestionAction/QuestionAction";
 
+import { QuestionStep } from "@/app/components/Question/Question";
 import { QuestionType } from "@prisma/client";
 import { fn } from "@storybook/test";
-import { QuestionStep } from "@/app/components/Question/Question";
 
 const meta = {
   title: "Cards/Question Action",
@@ -27,10 +27,10 @@ type Story = StoryObj<typeof meta>;
 
 export const TrueFalse: Story = {
   args: {
-    type: QuestionType.TrueFalse,
+    type: QuestionType.BinaryQuestion,
     questionOptions: [
-      { id: 1, option: "False" },
-      { id: 2, option: "True" },
+      { id: 1, option: "False", isLeft: false },
+      { id: 2, option: "True", isLeft: true },
     ],
     step: QuestionStep.AnswerQuestion,
   },
@@ -45,10 +45,10 @@ export const MultipleChoice: Story = {
 
 export const TrueFalsePercentage: Story = {
   args: {
-    type: QuestionType.TrueFalse,
+    type: QuestionType.BinaryQuestion,
     questionOptions: [
-      { id: 1, option: "False" },
-      { id: 2, option: "True" },
+      { id: 1, option: "False", isLeft: false },
+      { id: 2, option: "True", isLeft: true },
     ],
     step: QuestionStep.PickPercentage,
   },

--- a/stories/TrueFalseScale.stories.tsx
+++ b/stories/TrueFalseScale.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { TrueFalseScale } from "../app/components/TrueFalseScale/TrueFalseScale";
 import AvatarSample from "./assets/avatar_sample.png";
-import { fn } from "@storybook/test";
 
 const meta = {
   title: "True False Scale",
@@ -11,12 +11,14 @@ const meta = {
   },
   tags: ["autodocs"],
   args: {
-    ratioTrue: 80,
+    ratioLeft: 80,
+    labelLeft: "True",
+    labelRight: "False",
     avatarSrc: AvatarSample.src,
     handleRatioChange: fn(),
   },
   argTypes: {
-    ratioTrue: { type: "number" },
+    ratioLeft: { type: "number" },
     valueSelected: { type: "number" },
   },
   decorators: (Story) => (


### PR DESCRIPTION
- Description:
This PR addresses the ability to create binary questions with arbitrary values for the option label instead of fixed T/F and Y/N question types.
- ClickUp links: Not applicable
- What are the acceptance criteria? What are the steps to test that this code is working?
AC 1:
Ability to add binary question using admin panel
AC 2:
Ability to add binary question to deck using admin panel
AC 3:
Ability to answer binary question
AC 4:
Ability to display result for binary question

In order to test this code we need to run the provided seed script inside of deck md, which will verify ability to answer binary questions.
(AC's should be self explanatory, with the caveat that you do need to set yourself as admin user through db query.)