### PR TITLE
fix: styling of no answer-page

### DIFF
--- a/app/components/NoQuestionsCard/NoQuestionsCard.tsx
+++ b/app/components/NoQuestionsCard/NoQuestionsCard.tsx
@@ -27,11 +27,11 @@ export function NoQuestionsCard({
           aspectRatio: 0.92,
         }}
       >
-        <div>
+        <div className="text-center flex items-center justify-start flex-col h-full gap-10">
           <div className="text-2xl font-bold mb-2">
             {QUESTION_CARD_CONTENT[variant].title}
           </div>
-          <div className="text-sm max-w-72 relative z-10">
+          <div className="text-base relative z-10">
             {QUESTION_CARD_CONTENT[variant].body}
           </div>
         </div>

--- a/app/components/NoQuestionsCard/constants.tsx
+++ b/app/components/NoQuestionsCard/constants.tsx
@@ -32,8 +32,8 @@ export const QUESTION_CARD_CONTENT = {
     title: "Wait, is there more?",
     body: (
       <>
-        There just might be! <br /> <br /> Check out what decks are still
-        available for you to chomp through under &quot;Home&quot;!
+        There just might be! <br /> Check out what decks are still available for
+        you to chomp through under &quot;Home&quot;!
       </>
     ),
   },


### PR DESCRIPTION
- Description:
- ClickUp links:
- What are the acceptance criteria? What are the steps to test that this code is working?

I have just updated the style of answer page card component 

from:
<img width="1511" alt="Screenshot 2024-06-04 at 14 49 16" src="https://github.com/gator-labs/chomp/assets/96897046/da916321-5d35-41d4-ac10-3915ca49ccdc">

To:

<img width="1511" alt="Screenshot 2024-06-04 at 14 48 31" src="https://github.com/gator-labs/chomp/assets/96897046/c5e8b4e3-c6b4-4717-bf96-c1959065437a">

As it was very small fix, I did not create a ticket for it