### PR TITLE
Fixed Leaderboard ranking page break due empty wallet address

### DIFF
--- a/app/components/LeaderboardRanking/LeaderboardRanking.tsx
+++ b/app/components/LeaderboardRanking/LeaderboardRanking.tsx
@@ -32,7 +32,11 @@ const LeaderboardRanking = ({ label, loggedUserId, ranking }: Props) => {
                 key={rankItem.user.id}
                 value={rankItem.value}
                 rank={rankItem.rank}
-                name={formatAddress(rankItem.user.wallets[0]?.address)}
+                name={
+                  rankItem.user.wallets[0]?.address
+                    ? formatAddress(rankItem.user.wallets[0].address)
+                    : "mocked user"
+                }
                 loggedUserId={loggedUserId}
                 userId={rankItem.user.id}
                 imageSrc={rankItem.user!.profileSrc || AvatarPlaceholder.src}


### PR DESCRIPTION
- Description:
- Fix for empty wallet addresses (Script users)
![2024-07-30 18 27 12](https://github.com/user-attachments/assets/28a86c03-103c-4fb6-aa96-550dc1d581b7)
![2024-07-30 18 27 20](https://github.com/user-attachments/assets/bbd15be7-e42d-42c5-b53a-494e7b79861d)

- ClickUp links:
- What are the acceptance criteria? What are the steps to test that this code is working?
