### PR TITLE
[PROD-48] fix: correct regular decks logic

### DIFF
--- a/app/api/question/get/route.ts
+++ b/app/api/question/get/route.ts
@@ -78,14 +78,15 @@ export async function GET(req: Request) {
     return Response.json({ question: getRandomElement(getDailyDeckQuestions) });
   } else {
     // Unanwsered Questions
-    const dailyDeckQuestions = await prisma.deckQuestion.findMany({
+    const regularDeckQuestions = await prisma.deckQuestion.findMany({
       where: {
         deck: {
-          date: {
-            gte: dayjs(new Date()).add(-3, "days").toDate(),
-            lte: dayjs(new Date()).endOf("day").toDate(),
+          revealAtDate: {
+            gte: new Date(),
+            lte: new Date(new Date().getTime() + 3 * 24 * 60 * 60 * 1000),
           },
-          revealAtDate: { gte: new Date() },
+          isActive: true,
+          date: null,
         },
         question: {
           question: { contains: "", mode: "insensitive" },
@@ -118,7 +119,7 @@ export async function GET(req: Request) {
       },
     });
 
-    const questions = dailyDeckQuestions.map((dq) => dq.question);
+    const questions = regularDeckQuestions.map((dq) => dq.question);
 
     if (questions.length === 0)
       new Response(`No questions found to load`, {

--- a/app/api/question/get/route.ts
+++ b/app/api/question/get/route.ts
@@ -77,17 +77,30 @@ export async function GET(req: Request) {
   if (getDailyDeckQuestions && getDailyDeckQuestions.length > 0) {
     return Response.json({ question: getRandomElement(getDailyDeckQuestions) });
   } else {
-    // Unanwsered Questions
-    const regularDeckQuestions = await prisma.deckQuestion.findMany({
+    // Deck Questions includes questions from Regular Decks and unanwered Daily Decks
+    const deckQuestions = await prisma.deckQuestion.findMany({
       where: {
-        deck: {
-          revealAtDate: {
-            gte: new Date(),
-            lte: new Date(new Date().getTime() + 3 * 24 * 60 * 60 * 1000),
+        OR: [
+          {
+            deck: {
+              revealAtDate: {
+                gte: new Date(),
+                lte: new Date(new Date().getTime() + 3 * 24 * 60 * 60 * 1000),
+              },
+              isActive: true,
+              date: null,
+            },
           },
-          isActive: true,
-          date: null,
-        },
+          {
+            deck: {
+              date: {
+                gte: dayjs(new Date()).add(-3, "days").toDate(),
+                lte: dayjs(new Date()).endOf("day").toDate(),
+              },
+              revealAtDate: { gte: new Date() },
+            },
+          },
+        ],
         question: {
           question: { contains: "", mode: "insensitive" },
           questionOptions: {
@@ -119,7 +132,7 @@ export async function GET(req: Request) {
       },
     });
 
-    const questions = regularDeckQuestions.map((dq) => dq.question);
+    const questions = deckQuestions.map((dq) => dq.question);
 
     if (questions.length === 0)
       new Response(`No questions found to load`, {


### PR DESCRIPTION
- Description:
Correct the logic of fetching Regular Decks in Questions API

- ClickUp links:
https://app.clickup.com/t/86bzqmywj

- What are the acceptance criteria? What are the steps to test that this code is working?
Test route /api/question/get?userId={userId}