### PR TITLE
PROD-83: Fix/optimize burn fee

### DIFF
--- a/app/components/Bot/Bot.tsx
+++ b/app/components/Bot/Bot.tsx
@@ -131,7 +131,6 @@ export default function BotMiniApp() {
       const burnTx = await signer.signAndSendTransaction(tx);
 
       setIsBurnInProgress(true);
-      // Process Burn and Claim
       const processedData = await processBurnAndClaim(
         userId!,
         burnTx?.signature,

--- a/app/queries/getPriorityFeeEstimate.ts
+++ b/app/queries/getPriorityFeeEstimate.ts
@@ -1,0 +1,23 @@
+export const getRecentPrioritizationFees = async () => {
+  const response = await fetch(process.env.NEXT_PUBLIC_RPC_URL!, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getPriorityFeeEstimate",
+      params: [
+        {
+          accountKeys: ["JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"],
+          options: {
+            includeAllPriorityFeeLevels: true,
+          },
+        },
+      ],
+    }),
+  });
+  const data = await response.json();
+  return data;
+};

--- a/app/queries/getPriorityFeeEstimate.ts
+++ b/app/queries/getPriorityFeeEstimate.ts
@@ -1,4 +1,6 @@
-export const getRecentPrioritizationFees = async () => {
+import { Transaction } from "@solana/web3.js";
+
+export const getRecentPrioritizationFees = async (tx: Transaction) => {
   const response = await fetch(process.env.NEXT_PUBLIC_RPC_URL!, {
     method: "POST",
     headers: {
@@ -10,8 +12,8 @@ export const getRecentPrioritizationFees = async () => {
       method: "getPriorityFeeEstimate",
       params: [
         {
-          accountKeys: ["JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4"],
           options: {
+            transaction: tx,
             includeAllPriorityFeeLevels: true,
           },
         },

--- a/app/utils/solana.ts
+++ b/app/utils/solana.ts
@@ -9,6 +9,7 @@ import {
   PublicKey,
   Transaction,
 } from "@solana/web3.js";
+import { getRecentPrioritizationFees } from "../queries/getPriorityFeeEstimate";
 
 export const CONNECTION = new Connection(process.env.NEXT_PUBLIC_RPC_URL!);
 
@@ -21,21 +22,25 @@ export const genBonkBurnTx = async (
   blockhash: string,
   tokenAmount: number,
 ) => {
-  const burnFromPublic = new PublicKey(ownerAddress);
+  const burnFromPublic = new PublicKey(ownerAddress); // user address
+  const bonkPublic = new PublicKey(BONK_PUBLIC_ADDRESS); // bonk public address
 
-  const bonkPublic = new PublicKey(BONK_PUBLIC_ADDRESS);
-  let ata = await getAssociatedTokenAddress(
-    bonkPublic, // mint
-    burnFromPublic, // owner
-  );
+  let ata = await getAssociatedTokenAddress(bonkPublic, burnFromPublic);
+
+  const estimateFee = await getRecentPrioritizationFees();
 
   const tx = new Transaction();
 
-  const priorityFeeInstruction = ComputeBudgetProgram.setComputeUnitPrice({
-    microLamports: 1000000,
+  const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({
+    units: 10000,
   });
 
-  tx.add(priorityFeeInstruction);
+  const addPriorityFee = ComputeBudgetProgram.setComputeUnitPrice({
+    microLamports: estimateFee?.result?.priorityFeeLevels?.medium,
+  });
+
+  tx.add(modifyComputeUnits);
+  tx.add(addPriorityFee);
 
   tx.add(
     createBurnCheckedInstruction(

--- a/app/utils/solana.ts
+++ b/app/utils/solana.ts
@@ -37,23 +37,24 @@ export const genBonkBurnTx = async (
     DECIMALS,
   );
 
-  tx.add(burnTxInstruction);
-
   tx.recentBlockhash = blockhash;
   tx.feePayer = burnFromPublic;
 
   const estimateFee = await getRecentPrioritizationFees(tx);
 
+  const computeUnitFix = 5000;
+
   const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({
-    units: 10000,
+    units: computeUnitFix * 1.25,
   });
 
   const addPriorityFee = ComputeBudgetProgram.setComputeUnitPrice({
-    microLamports: estimateFee?.result?.priorityFeeLevels?.medium,
+    microLamports: estimateFee?.result?.priorityFeeLevels?.high,
   });
 
   tx.add(modifyComputeUnits);
   tx.add(addPriorityFee);
+  tx.add(burnTxInstruction);
 
   return tx;
 };

--- a/app/utils/solana.ts
+++ b/app/utils/solana.ts
@@ -27,9 +27,22 @@ export const genBonkBurnTx = async (
 
   let ata = await getAssociatedTokenAddress(bonkPublic, burnFromPublic);
 
-  const estimateFee = await getRecentPrioritizationFees();
-
   const tx = new Transaction();
+
+  const burnTxInstruction = createBurnCheckedInstruction(
+    ata,
+    bonkPublic,
+    burnFromPublic,
+    tokenAmount * 10 ** DECIMALS,
+    DECIMALS,
+  );
+
+  tx.add(burnTxInstruction);
+
+  tx.recentBlockhash = blockhash;
+  tx.feePayer = burnFromPublic;
+
+  const estimateFee = await getRecentPrioritizationFees(tx);
 
   const modifyComputeUnits = ComputeBudgetProgram.setComputeUnitLimit({
     units: 10000,
@@ -41,19 +54,6 @@ export const genBonkBurnTx = async (
 
   tx.add(modifyComputeUnits);
   tx.add(addPriorityFee);
-
-  tx.add(
-    createBurnCheckedInstruction(
-      ata,
-      bonkPublic,
-      burnFromPublic,
-      tokenAmount * 10 ** DECIMALS,
-      DECIMALS,
-    ),
-  );
-
-  tx.recentBlockhash = blockhash;
-  tx.feePayer = burnFromPublic;
 
   return tx;
 };


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
Added Estimate priority function from helius api to get an approrate fees along with adding compute unit in the transaction to increase the sucess rate of the burn transation with very low fees
- What are the steps to test that this code is working?
Low priority fees, high success rate. 
- Screen shots or recordings for UI changes
There is no ui changes
