### PR TITLE
PROD-214 added timed-out question answer status

### DIFF
--- a/app/actions/answer.ts
+++ b/app/actions/answer.ts
@@ -282,3 +282,31 @@ export async function markQuestionAsSeenButNotAnswered(questionId: number) {
     return { hasError: true };
   }
 }
+
+export async function markQuestionAsTimedOut(questionId: number) {
+  const payload = await getJwtPayload();
+
+  if (!payload) return;
+
+  const userId = payload.sub;
+
+  const questionOptions = await prisma.questionOption.findMany({
+    where: { questionId },
+  });
+
+  try {
+    await prisma.questionAnswer.updateMany({
+      where: {
+        userId,
+        questionOptionId: {
+          in: questionOptions.map((qo) => qo.id),
+        },
+      },
+      data: {
+        status: AnswerStatus.TimedOut,
+      },
+    });
+  } catch (error) {
+    return { hasError: true };
+  }
+}

--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -2,6 +2,7 @@
 import {
   answerQuestion,
   markQuestionAsSeenButNotAnswered,
+  markQuestionAsTimedOut,
   SaveQuestionRequest,
 } from "@/app/actions/answer";
 import { useRandom } from "@/app/hooks/useRandom";
@@ -137,8 +138,10 @@ export function Deck({
     if (!!question?.id) run();
   }, [question?.id]);
 
-  const handleNoAnswer = useCallback(() => {
+  const handleNoAnswer = useCallback(async () => {
     setIsTimeOutPopUpVisible(false);
+
+    await markQuestionAsTimedOut(question.id);
 
     handleNextIndex();
   }, [question, handleNextIndex, setDeckResponse]);

--- a/prisma/migrations/20240902163858_add_timed_out_to_question_answer/migration.sql
+++ b/prisma/migrations/20240902163858_add_timed_out_to_question_answer/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "AnswerStatus" ADD VALUE 'TimedOut';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -294,4 +294,5 @@ enum NftType {
 enum AnswerStatus {
   Viewed
   Submitted
+  TimedOut
 }


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
  Link to the task https://linear.app/gator/issue/PROD-214/create-timedout-status-for-questionanswer
  updated enum for question answer status. After time for the question expires, that question is marked as timedOut
- What are the steps to test that this code is working?
- Screen shots or recordings for UI changes
