### PR TITLE
PROD-277/incorrect-deck-reveal-state 

### DIFF
--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -73,7 +73,7 @@ const CampaignPage = async ({ params: { id } }: PageProps) => {
                 dq.question.questionOptions.flatMap((qo) => qo.questionAnswers),
               ).length
             }
-            activeFromDate={deck.activeFromDate!}
+            activeFromDate={deck.activeFromDate || deck.createdAt}
           />
         ))}
       </ul>


### PR DESCRIPTION
Some older decks do not have activeFromDate so I added createdAt to be read if there is no activeFromDate. Another alternative is to update those decks by hand in db and add them activeFromDate.