### PR TITLE
Prod 270/proceed after timer runs out

### DIFF
--- a/app/actions/answer.ts
+++ b/app/actions/answer.ts
@@ -346,6 +346,9 @@ export async function markQuestionAsSkipped(questionId: number) {
   });
 
   try {
+    console.log("userId", userId);
+    console.log("questionOptions", questionOptions);
+    console.log("markQuestionAsSkipped");
     await prisma.questionAnswer.updateMany({
       where: {
         userId,
@@ -357,6 +360,7 @@ export async function markQuestionAsSkipped(questionId: number) {
         status: AnswerStatus.Skipped,
       },
     });
+    console.log("finished markQuestionAsSkipped");
   } catch (error) {
     return { hasError: true };
   }

--- a/app/actions/answer.ts
+++ b/app/actions/answer.ts
@@ -346,9 +346,6 @@ export async function markQuestionAsSkipped(questionId: number) {
   });
 
   try {
-    console.log("userId", userId);
-    console.log("questionOptions", questionOptions);
-    console.log("markQuestionAsSkipped");
     await prisma.questionAnswer.updateMany({
       where: {
         userId,
@@ -360,7 +357,6 @@ export async function markQuestionAsSkipped(questionId: number) {
         status: AnswerStatus.Skipped,
       },
     });
-    console.log("finished markQuestionAsSkipped");
   } catch (error) {
     return { hasError: true };
   }

--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -135,7 +135,6 @@ export function Deck({
 
   useEffect(() => {
     const run = async () => {
-      console.log("triggered");
       const res = await markQuestionAsSeenButNotAnswered(question.id);
       if (!!res?.hasError) {
         handleNextIndex();

--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -152,14 +152,11 @@ export function Deck({
   }, [question, handleNextIndex, setDeckResponse]);
 
   const handleOnDurationRanOut = useCallback(async () => {
-    console.log("handleOnDurationRanOut");
     await markQuestionAsTimedOut(question.id);
     setIsTimeOutPopUpVisible(true);
-    console.log("handleOnDurationRanOut");
   }, [question, handleNextIndex, setDeckResponse]);
 
   const handleSkipQuestion = async () => {
-    console.log("handleSkipQuestion");
     await markQuestionAsSkipped(question.id);
     handleNextIndex();
   };

--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -20,7 +20,6 @@ import { QuestionStep } from "../Question/Question";
 import { QuestionAction } from "../QuestionAction/QuestionAction";
 import { QuestionCard } from "../QuestionCard/QuestionCard";
 import { QuestionCardContent } from "../QuestionCardContent/QuestionCardContent";
-import Sheet from "../Sheet/Sheet";
 import Stepper from "../Stepper/Stepper";
 import {
   AlertDialog,
@@ -29,7 +28,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "../ui/alert-dialog";
-import { Button } from "../ui/button"
+import { Button } from "../ui/button";
 
 export type Option = {
   id: number;
@@ -85,7 +84,7 @@ export function Deck({
   const min = 0;
   const max =
     !!questions[currentQuestionIndex] &&
-      questions[currentQuestionIndex].questionOptions.length > 0
+    questions[currentQuestionIndex].questionOptions.length > 0
       ? questions[currentQuestionIndex].questionOptions.length - 1
       : 0;
 
@@ -113,7 +112,7 @@ export function Deck({
     const min = 0;
     const max =
       !!questions[currentQuestionIndex + 1] &&
-        questions[currentQuestionIndex + 1].questionOptions.length > 0
+      questions[currentQuestionIndex + 1].questionOptions.length > 0
         ? questions[currentQuestionIndex + 1].questionOptions.length - 1
         : 0;
     generateRandom({ min, max });
@@ -136,6 +135,7 @@ export function Deck({
 
   useEffect(() => {
     const run = async () => {
+      console.log("triggered");
       const res = await markQuestionAsSeenButNotAnswered(question.id);
       if (!!res?.hasError) {
         handleNextIndex();
@@ -151,12 +151,15 @@ export function Deck({
     handleNextIndex();
   }, [question, handleNextIndex, setDeckResponse]);
 
-  const handleOnDurationRanOut = async () => {
+  const handleOnDurationRanOut = useCallback(async () => {
+    console.log("handleOnDurationRanOut");
     await markQuestionAsTimedOut(question.id);
     setIsTimeOutPopUpVisible(true);
-  };
+    console.log("handleOnDurationRanOut");
+  }, [question, handleNextIndex, setDeckResponse]);
 
   const handleSkipQuestion = async () => {
+    console.log("handleSkipQuestion");
     await markQuestionAsSkipped(question.id);
     handleNextIndex();
   };
@@ -282,7 +285,7 @@ export function Deck({
             question={question.question}
             type={question.type}
             viewImageSrc={question.imageUrl}
-            onDurationRanOut={() => handleOnDurationRanOut()}
+            onDurationRanOut={handleOnDurationRanOut}
           >
             <QuestionCardContent
               optionSelectedId={currentOptionSelected}
@@ -313,11 +316,13 @@ export function Deck({
       >
         Skip question
       </div>
-      
+
       <AlertDialog open={isTimeOutPopUpVisible}>
         <AlertDialogContent onEscapeKeyDown={(e) => e.preventDefault()}>
           <AlertDialogHeader>
-            <AlertDialogTitle className="text-secondary">Are you still there?</AlertDialogTitle>
+            <AlertDialogTitle className="text-secondary">
+              Are you still there?
+            </AlertDialogTitle>
             <AlertDialogDescription className="text-white">
               Your time&apos;s up! To prevent you from missing out on the next
               question, click proceed to continue.

--- a/app/components/QuestionCard/QuestionCard.tsx
+++ b/app/components/QuestionCard/QuestionCard.tsx
@@ -3,7 +3,13 @@ import { QuestionType } from "@prisma/client";
 import classNames from "classnames";
 import dayjs from "dayjs";
 import Image from "next/image";
-import { CSSProperties, ReactNode, useCallback, useState } from "react";
+import {
+  CSSProperties,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
 import gatorHeadImage from "../../../public/images/gator-head.png";
 import { useInterval } from "../../hooks/useInterval";
 import {
@@ -42,14 +48,24 @@ export function QuestionCard({
   const [dueAtFormatted, setDueAtFormatted] = useState<string>(
     dueAt ? getDueAtString(dueAt) : "",
   );
+  const [hasDurationRanOut, setHasDurationRanOut] = useState(false);
+
   const handleDueAtFormatted = useCallback(() => {
-    if (!dueAt) return;
+    if (!dueAt || hasDurationRanOut) return;
 
     setDueAtFormatted(getDueAtString(dueAt));
     if (dayjs(dueAt).diff(new Date(), "seconds") <= 0) {
-      onDurationRanOut && onDurationRanOut();
+      if (onDurationRanOut) {
+        onDurationRanOut();
+        setHasDurationRanOut(true);
+      }
     }
-  }, [setDueAtFormatted, dueAt, onDurationRanOut]);
+  }, [dueAt, onDurationRanOut, hasDurationRanOut]);
+
+  useEffect(() => {
+    // Reset the hasDurationRanOut state when the question changes
+    setHasDurationRanOut(false);
+  }, [question]); // This effect depends on the question prop
 
   useInterval(handleDueAtFormatted, ONE_SECOND_IN_MILLISECONDS);
 


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Proceed functionality was not working properly after the timer has ran out
- What are the steps to test that this code is working?
- Screen shots or recordings for UI changes

How to test:
- start a deck
- wait for the timer to run out
- wait for 30 seconds (at least) after the "proceed" pop up shows up
- click on proceed should result in new question along with reseted timer.