### PR TITLE
PROD-242 removed dollar sign

### DIFF
--- a/app/components/NoQuestionsCard/constants.tsx
+++ b/app/components/NoQuestionsCard/constants.tsx
@@ -24,9 +24,9 @@ export const QUESTION_CARD_CONTENT = {
         You just chomped through that deck!{" "}
         {!!date && (
           <>
-            The deck will be revealed in{" "}{" "}
+            The deck will be revealed in{" "}
             <span className="text-secondary">
-              ${formatDistanceToNowStrict(date)}
+              {formatDistanceToNowStrict(date)}
             </span>
             .
           </>


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task: https://linear.app/gator/issue/PROD-242/remove-dollar-sign-before-reveal-at-time 
- What are the steps to test that this code is working?
- Complete a deck and and home screen near reveal at time there should be no $ sign 
- Screen shots or recordings for UI changes
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
![Screenshot 2024-09-16 at 18 11 18](https://github.com/user-attachments/assets/a2caa4be-b764-4c6e-ac90-4a55997f066d)


