### PR TITLE
PROD-293 updated champaigns page

### DIFF
--- a/app/components/CampaignCard/CampaignCard.tsx
+++ b/app/components/CampaignCard/CampaignCard.tsx
@@ -23,6 +23,10 @@ const CampaignCard = ({
     <Link
       href={`/campaigns/${id}`}
       className="p-4 rounded-[8px] bg-gray-800 border-[0.5px] border-solid border-gray-500 flex items-center justify-between gap-4"
+      style={{
+        pointerEvents:
+          decksToAnswer === 0 && decksToReveal === 0 ? "none" : "auto",
+      }}
     >
       <div className="relative w-[52px] h-[52px]">
         <Image
@@ -34,19 +38,25 @@ const CampaignCard = ({
       </div>
       <div className="flex flex-col gap-3 flex-1">
         <h3 className="text-white text-sm font-bold">{name}</h3>
-        {decksToAnswer !== undefined && decksToReveal !== undefined && (
-          <p className="text-xs font-medium text-gray-400">
-            <span className="text-white">{decksToAnswer}</span> deck
-            {decksToAnswer === 1 ? "" : "s"} to answer{" "}
-            <span className="text-white">•</span>{" "}
-            <span className="text-white">{decksToReveal}</span> deck
-            {decksToReveal === 1 ? "" : "s"} to reveal
-          </p>
-        )}
+        {decksToAnswer !== undefined && decksToReveal !== undefined ? (
+          decksToAnswer === 0 && decksToReveal === 0 ? (
+            <p className="text-xs font-medium text-gray-400">Coming soon</p>
+          ) : (
+            <p className="text-xs font-medium text-gray-400">
+              <span className="text-white">{decksToAnswer}</span> deck
+              {decksToAnswer === 1 ? "" : "s"} to answer{" "}
+              <span className="text-white">•</span>{" "}
+              <span className="text-white">{decksToReveal}</span> deck
+              {decksToReveal === 1 ? "" : "s"} to reveal
+            </p>
+          )
+        ) : null}
       </div>
-      <div className="flex-shrink-0">
-        <ArrowRightCircle />
-      </div>
+      {!(decksToAnswer === 0 && decksToReveal === 0) && (
+        <div className="flex-shrink-0">
+          <ArrowRightCircle />
+        </div>
+      )}
     </Link>
   );
 };

--- a/app/queries/campaign.ts
+++ b/app/queries/campaign.ts
@@ -90,7 +90,6 @@ export async function getAllCampaigns() {
   const campaigns = await prisma.campaign.findMany({
     where: {
       isVisible: true,
-      isActive: true,
     },
     include: {
       deck: {
@@ -120,6 +119,7 @@ export async function getAllCampaigns() {
         },
       },
     },
+    orderBy: [{ isActive: "desc" }, { createdAt: "desc" }],
   });
 
   return campaigns.map((campaign) => ({


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task: https://linear.app/gator/issue/PROD-293/campaigns-list-campaigns-clean-ups
   -Hidden decks that are marked isVisible:false
   -descending order by latest active decks
   -disable click for zero state decks 
   -removed right arrow for zero state decks
- What are the steps to test that this code is working?
- Screen shots or recordings for UI changes
![Screenshot 2024-09-16 at 19 07 46](https://github.com/user-attachments/assets/733d829d-6648-4ccc-a2d9-9ada67927bda)
