### PR TITLE
Prod 301/is visible and is active campaigns behaviour

### DIFF
--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -16,7 +16,13 @@ type PageProps = {
 const CampaignPage = async ({ params: { id } }: PageProps) => {
   const campaign = await getCampaign(+id);
 
-  if (!campaign) return notFound();
+  console.log("campaign", campaign);
+
+  if (
+    !campaign ||
+    (campaign.isActive === false && campaign?.isVisible === false)
+  )
+    return notFound();
 
   return (
     <div className="flex flex-col gap-2 pt-4 overflow-hidden pb-2">

--- a/app/components/CampaignCard/CampaignCard.tsx
+++ b/app/components/CampaignCard/CampaignCard.tsx
@@ -23,6 +23,10 @@ const CampaignCard = ({
     <Link
       href={`/campaigns/${id}`}
       className="p-4 rounded-[8px] bg-gray-800 border-[0.5px] border-solid border-gray-500 flex items-center justify-between gap-4"
+      style={{
+        pointerEvents:
+          decksToAnswer === 0 && decksToReveal === 0 ? "none" : "auto",
+      }}
     >
       <div className="relative w-[52px] h-[52px]">
         <Image
@@ -34,19 +38,25 @@ const CampaignCard = ({
       </div>
       <div className="flex flex-col gap-3 flex-1">
         <h3 className="text-white text-sm font-bold">{name}</h3>
-        {decksToAnswer !== undefined && decksToReveal !== undefined && (
-          <p className="text-xs font-medium text-gray-400">
-            <span className="text-white">{decksToAnswer}</span> deck
-            {decksToAnswer === 1 ? "" : "s"} to answer{" "}
-            <span className="text-white">•</span>{" "}
-            <span className="text-white">{decksToReveal}</span> deck
-            {decksToReveal === 1 ? "" : "s"} to reveal
-          </p>
-        )}
+        {decksToAnswer !== undefined && decksToReveal !== undefined ? (
+          decksToAnswer === 0 && decksToReveal === 0 ? (
+            <p className="text-xs font-medium text-gray-400">Coming soon</p>
+          ) : (
+            <p className="text-xs font-medium text-gray-400">
+              <span className="text-white">{decksToAnswer}</span> deck
+              {decksToAnswer === 1 ? "" : "s"} to answer{" "}
+              <span className="text-white">•</span>{" "}
+              <span className="text-white">{decksToReveal}</span> deck
+              {decksToReveal === 1 ? "" : "s"} to reveal
+            </p>
+          )
+        ) : null}
       </div>
-      <div className="flex-shrink-0">
-        <ArrowRightCircle />
-      </div>
+      {!(decksToAnswer === 0 && decksToReveal === 0) && (
+        <div className="flex-shrink-0">
+          <ArrowRightCircle />
+        </div>
+      )}
     </Link>
   );
 };

--- a/app/queries/campaign.ts
+++ b/app/queries/campaign.ts
@@ -45,8 +45,6 @@ export async function getCampaign(id: number) {
   return prisma.campaign.findUnique({
     where: {
       id,
-      isVisible: true,
-      isActive: true,
     },
     include: {
       deck: {

--- a/app/queries/campaign.ts
+++ b/app/queries/campaign.ts
@@ -90,7 +90,6 @@ export async function getAllCampaigns() {
   const campaigns = await prisma.campaign.findMany({
     where: {
       isVisible: true,
-      isActive: true,
     },
     include: {
       deck: {
@@ -120,6 +119,7 @@ export async function getAllCampaigns() {
         },
       },
     },
+    orderBy: [{ isActive: "desc" }, { createdAt: "desc" }],
   });
 
   return campaigns.map((campaign) => ({


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task: https://linear.app/gator/issue/PROD-301/isvisible-and-isactive-campaigns-behavior
- What are the steps to test that this code is working?
   - On staging DB I've created a Campaign (Andrej test) ID=16. Direct link to /campaigns/16 should result in 404.
   - On staging DB Campaigns Orca (id = 5) and Superteam Vietnam (id=14) are marked as isActive=true and 
      isVisible=false. They should not be displayed on the list but direct links should work /campaigns/5 and /campaigns/14
   - On staging DB Campaign id = 12 is marked as isActive=false and isVisible = true. Direct link should work /campaigns/12  
   and should be visible on the list
   - For the other Campaigns, direct links should work and they should appear on the list 
- Screen shots or recordings for UI changes
