### PR TITLE
PROD-302 removed skip functionality from second order question

### DIFF
--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -306,12 +306,14 @@ export function Deck({
         setPercentage={setOptionPercentage}
         disabled={isSubmitting}
       />
-      <div
-        className="text-sm text-center mt-5 text-gray-400 underline cursor-pointer"
-        onClick={() => handleSkipQuestion()}
-      >
-        Skip question
-      </div>
+      {currentQuestionStep !== QuestionStep.PickPercentage && (
+        <div
+          className="text-sm text-center mt-5 text-gray-400 underline cursor-pointer"
+          onClick={() => handleSkipQuestion()}
+        >
+          Skip question
+        </div>
+      )}
 
       <AlertDialog open={isTimeOutPopUpVisible}>
         <AlertDialogContent onEscapeKeyDown={(e) => e.preventDefault()}>


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task: https://linear.app/gator/issue/PROD-302/do-not-allow-skipping-second-order-question
- What are the steps to test that this code is working?
- Start a deck. Before selecting the answer the skip question should be possible. After selecting the answer the percentage slider should appear and skip question functionality should not be possible
- Screen shots or recordings for UI changes
![Screenshot 2024-09-16 at 20 38 46](https://github.com/user-attachments/assets/ef9e3494-ac42-41b0-9b83-4e733ec036e5)
![Screenshot 2024-09-16 at 20 39 03](https://github.com/user-attachments/assets/f4434641-7d8f-45a3-9276-728eaa0dcdd8)
