### PR TITLE
PROD-314 fixed spacing

### DIFF
--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -34,7 +34,7 @@ const CampaignPage = async ({ params: { id } }: PageProps) => {
         </div>
         <div className="flex flex-col">
           <h1 className="text-base mb-3">{campaign.name}</h1>
-          <p className="text-xs">
+          <p className="text-xs mb-6">
             {campaign.deck.length} deck{campaign.deck.length === 1 ? "" : "s"},{" "}
             {campaign.deck.flatMap((d) => d.deckQuestions).length} cards
           </p>


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the task https://linear.app/gator/issue/PROD-314/fix-spacing-between-leaderboards-and-deck-counts
- What are the steps to test that this code is working?
 Go to Campaign's details page . Spacing should be as it is in the design
- Screen shots or recordings for UI changes
![Screen Shot 2024-09-16 at 23 02 20 PM](https://github.com/user-attachments/assets/a3cc5d78-05d4-4ba7-a36a-92fae00055ec)
![Screenshot 2024-09-16 at 23 03 01](https://github.com/user-attachments/assets/fe19cf92-b4c5-4f19-b98c-a6b515aa2cb0)
