### PR TITLE
PROD-284: default daily deck time 0:00 UTC

### DIFF
--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -17,7 +17,6 @@ import { TextInput } from "../TextInput/TextInput";
 import dayjs from "dayjs";
 import utc from 'dayjs/plugin/utc'
 
-dayjs.extend(utc);
 
 type DeckFormProps = {
   deck?: z.infer<typeof deckSchema>;
@@ -34,6 +33,7 @@ export default function DeckForm({
   campaigns,
   action,
 }: DeckFormProps) {
+  dayjs.extend(utc);
   const { errorToast } = useToast();
 
   const {

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -14,6 +14,10 @@ import { Button } from "../Button/Button";
 import { getDefaultOptions } from "../QuestionForm/QuestionForm";
 import { Tag } from "../Tag/Tag";
 import { TextInput } from "../TextInput/TextInput";
+import dayjs from "dayjs";
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc);
 
 type DeckFormProps = {
   deck?: z.infer<typeof deckSchema>;
@@ -42,6 +46,7 @@ export default function DeckForm({
   } = useForm({
     resolver: zodResolver(deckSchema),
     defaultValues: deck || {
+      date: dayjs().utc().startOf('day').toDate(),
       questions: [
         {
           type: QuestionType.MultiChoice,


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description: Daily deck time defaults to 0:00 UTC
- What are the steps to test that this code is working?
  - New deck form should display 0:00 UTC: https://chomp-git-ma-prod-284default-daily-time-gator-labs.vercel.app/admin/decks/new
  - Editing an existing daily deck should show the time that was already set: https://chomp-git-ma-prod-284default-daily-time-gator-labs.vercel.app/admin/decks/214
- Screen shots or recordings for UI changes

In this example, user's time is UTC-5
<img width="333" alt="Screenshot 2024-09-17 at 2 42 35 AM" src="https://github.com/user-attachments/assets/2e0dbd4d-9e09-4274-8152-fd0032793871">

