### PR TITLE
fix: do not set daily deck date by default

### DIFF
--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -46,7 +46,6 @@ export default function DeckForm({
   } = useForm({
     resolver: zodResolver(deckSchema),
     defaultValues: deck || {
-      date: dayjs().utc().startOf('day').toDate(),
       questions: [
         {
           type: QuestionType.MultiChoice,
@@ -65,6 +64,8 @@ export default function DeckForm({
   const [selectedCampaignId, setSelectedCampaignId] = useState(
     deck?.campaignId || undefined,
   );
+
+  const [previousDate, setPreviousDate] = useState<Date | undefined | null>(deck ? deck.date : undefined);
 
   const file = watch("file")?.[0];
   const deckImage = watch("imageUrl");
@@ -460,7 +461,17 @@ export default function DeckForm({
             <DatePicker
               showIcon
               selected={field.value}
-              onChange={field.onChange}
+              onChange={(date) => {
+                // If the new date is different from the previous date
+                if (!previousDate || dayjs(date).format('YYYY-MM-DD') !== dayjs(previousDate).format('YYYY-MM-DD')) {
+                  const newDate = dayjs(date).utc().startOf('day').toDate();  // Set time to 00:00 UTC
+                  field.onChange(newDate);  // Set the date with UTC midnight time
+                  setPreviousDate(newDate); // Update the previous date
+                } else {
+                  // If only the time has changed, keep the original date
+                  field.onChange(date);
+                }
+              }}
               placeholderText="Daily deck date"
               showTimeInput
               dateFormat="Pp"


### PR DESCRIPTION
Follow up to: https://linear.app/gator/issue/PROD-284/default-daily-deck-to-the-same-time-every-day

- Description: Was mistakenly setting daily deck date for all new questions. Instead it should be blank by default and only set to midnight UTC if user selects a daily deck date. 
- What are the steps to test that this code is working?
 - Create new deck: 1) daily deck date should be empty, 2) select daily deck date -> should be set to 0:00 UTC on that day, 3) update time on same day -> new time should be accepted, 4) set a new date -> time should be reset to 0:00 UTC
 - Edit a new deck. 1) Daily deck date should be what was previously set, 2) if changing datetime, behavior should be same as above.  
- Screen shots or recordings for UI changes
