### PR TITLE
PROD-193: fix daily deck redirect

### DIFF
--- a/app/queries/deck.ts
+++ b/app/queries/deck.ts
@@ -177,14 +177,14 @@ export async function getDeckQuestionsForAnswerById(deckId: number) {
         date: deck.date,
         dailyDeckActive:
           !!deck.activeFromDate && !isAfter(deck.activeFromDate, new Date()),
-        name: deck.deck
-      }
+        name: deck.deck,
+      };
     } else {
       return {
         questions: [],
         id: deck.id,
         date: deck.date,
-      }
+      };
     }
   }
 
@@ -265,8 +265,8 @@ export async function getDecks() {
 }
 
 export async function getDailyAnsweredQuestions() {
-  const currentDayStart = dayjs(new Date()).startOf("day").toDate();
-  const currentDayEnd = dayjs(new Date()).endOf("day").toDate();
+  const currentDayStart = dayjs(new Date()).subtract(1, "day").toDate();
+  const currentDayEnd = dayjs(new Date()).toDate();
   const payload = await getJwtPayload();
 
   if (!payload) {
@@ -274,6 +274,7 @@ export async function getDailyAnsweredQuestions() {
   }
 
   const dailyDeck = await prisma.deck.findFirst({
+    orderBy: [{ date: "asc" }],
     where: {
       date: { gte: currentDayStart, lte: currentDayEnd },
       deckQuestions: {


### PR DESCRIPTION
Description: daily deck page and home page have different logic for daily deck detection which causes an infinite loop with some combinations of time/timezone

Intended to supercede: https://github.com/gator-labs/chomp/pull/519

What are the steps to test that this code is working?
- create a daily deck
- go to /application
- expect to be taken to daily deck without loops


