### PR TITLE
PROD-320 enabled adding and editing decks without initial questions

### DIFF
--- a/app/actions/deck/deck.ts
+++ b/app/actions/deck/deck.ts
@@ -355,7 +355,7 @@ export async function editDeck(data: z.infer<typeof deckSchema>) {
           },
         });
 
-        await prisma.deckQuestion.create({
+        await tx.deckQuestion.create({
           data: {
             deckId: deck.id,
             questionId: res.id,
@@ -430,6 +430,13 @@ export async function editDeck(data: z.infer<typeof deckSchema>) {
             question.questionOptions,
           );
         }
+      }
+
+      if (
+        existingDeckQuestions.length === 0 &&
+        currentDeckQuestions.length === 0
+      ) {
+        return;
       }
 
       await tx.deckQuestion.deleteMany({

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -5,6 +5,8 @@ import { deckSchema } from "@/app/schemas/deck";
 import { uploadImageToS3Bucket } from "@/app/utils/file";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Campaign, QuestionType, Tag as TagType, Token } from "@prisma/client";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 import DatePicker from "react-datepicker";
@@ -14,9 +16,6 @@ import { Button } from "../Button/Button";
 import { getDefaultOptions } from "../QuestionForm/QuestionForm";
 import { Tag } from "../Tag/Tag";
 import { TextInput } from "../TextInput/TextInput";
-import dayjs from "dayjs";
-import utc from 'dayjs/plugin/utc'
-
 
 type DeckFormProps = {
   deck?: z.infer<typeof deckSchema>;
@@ -62,7 +61,9 @@ export default function DeckForm({
 
   const [selectedTagIds, setSelectedTagIds] = useState(deck?.tagIds ?? []);
 
-  const [previousDate, setPreviousDate] = useState<Date | undefined | null>(deck ? deck.date : undefined);
+  const [previousDate, setPreviousDate] = useState<Date | undefined | null>(
+    deck ? deck.date : undefined,
+  );
 
   const file = watch("file")?.[0];
   const deckImage = watch("imageUrl");
@@ -358,11 +359,13 @@ export default function DeckForm({
             type="button"
             onClick={() => {
               append({
-                type: fields[fields.length - 1].type,
+                type: fields[fields.length - 1]
+                  ? fields[fields.length - 1].type
+                  : QuestionType.MultiChoice,
                 question: "",
-                questionOptions: getDefaultOptions(
-                  fields[fields.length - 1].type,
-                ),
+                questionOptions: fields[fields.length - 1]
+                  ? getDefaultOptions(fields[fields.length - 1].type)
+                  : getDefaultOptions(QuestionType.MultiChoice),
               });
             }}
           >
@@ -452,9 +455,13 @@ export default function DeckForm({
               selected={field.value}
               onChange={(date) => {
                 // If the new date is different from the previous date
-                if (!previousDate || dayjs(date).format('YYYY-MM-DD') !== dayjs(previousDate).format('YYYY-MM-DD')) {
-                  const newDate = dayjs(date).utc().startOf('day').toDate();  // Set time to 00:00 UTC
-                  field.onChange(newDate);  // Set the date with UTC midnight time
+                if (
+                  !previousDate ||
+                  dayjs(date).format("YYYY-MM-DD") !==
+                    dayjs(previousDate).format("YYYY-MM-DD")
+                ) {
+                  const newDate = dayjs(date).utc().startOf("day").toDate(); // Set time to 00:00 UTC
+                  field.onChange(newDate); // Set the date with UTC midnight time
                   setPreviousDate(newDate); // Update the previous date
                 } else {
                   // If only the time has changed, keep the original date


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task https://linear.app/gator/issue/PROD-320/not-able-to-add-questions-to-a-deck-that-was-originally-created
- What are the steps to test that this code is working?
- Create a new deck without any questions inside. After successfully created deck click on the edit and add questions. Submit should pass without any error. Click again on the deck details and questions should be applied. Please go through standard flow in order to check if this change breaks existing deck flow behaviour
- Screen shots or recordings for UI changes
