### PR TITLE
Prod 322/redirect to deck after loggin in from campaings

### DIFF
--- a/app/components/CampaignDeckCard/CampaignDeckCard.tsx
+++ b/app/components/CampaignDeckCard/CampaignDeckCard.tsx
@@ -170,6 +170,7 @@ const CampaignDeckCard = ({
           setIsLoginModalOpen(false);
         }}
         userId={userId}
+        deckId={deckId}
       />
 
       <Wrapper

--- a/app/components/LoginPopUp/LoginPopUp.tsx
+++ b/app/components/LoginPopUp/LoginPopUp.tsx
@@ -6,6 +6,7 @@ import {
   DynamicConnectButton,
   useDynamicContext,
 } from "@dynamic-labs/sdk-react-core";
+import { RedirectType, redirect } from "next/navigation";
 import { useEffect, useState } from "react";
 import { CloseIcon } from "../Icons/CloseIcon";
 import { Button } from "../ui/button";
@@ -15,23 +16,46 @@ type LoginPopUpProps = {
   isOpen: boolean;
   onClose: () => void;
   userId?: string;
+  deckId: number;
 };
 
-const LoginPopUp = ({ isOpen, onClose, userId }: LoginPopUpProps) => {
+const LoginPopUp = ({ isOpen, onClose, userId, deckId }: LoginPopUpProps) => {
   const { authToken, awaitingSignatureState } = useDynamicContext();
   const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if(localStorage.getItem("selectedDeckId")) {
+      localStorage.removeItem("selectedDeckId");
+    }
+  }, []);
 
   useEffect(() => {
     setIsLoading(true);
 
     if (authToken) setJwt(authToken);
 
-    if (!!userId && !!authToken && awaitingSignatureState === "idle") {
+    if (
+      !!userId &&
+      !!authToken &&
+      awaitingSignatureState === "idle" &&
+      !localStorage.getItem("selectedDeckId")
+    ) {
       setIsLoading(false);
     }
+    if (
+      !!userId &&
+      !!authToken &&
+      awaitingSignatureState === "idle" &&
+      localStorage.getItem("selectedDeckId")
+    ) {
+      const selectedDeckId = localStorage.getItem("selectedDeckId");
+      localStorage.removeItem("selectedDeckId");
+      redirect(`/application/decks/${selectedDeckId}`, RedirectType.push);
+    }
 
-    if (!userId && !authToken && awaitingSignatureState === "idle")
+    if (!userId && !authToken && awaitingSignatureState === "idle") {
       setIsLoading(false);
+    }
   }, [authToken, userId, awaitingSignatureState]);
 
   if (isLoading) return <LoadingScreen />;
@@ -58,12 +82,17 @@ const LoginPopUp = ({ isOpen, onClose, userId }: LoginPopUpProps) => {
           Connect your wallet to answer questions and win prizes!
         </p>
 
-        <DynamicConnectButton
-          buttonContainerClassName="w-full"
-          buttonClassName="bg-purple-500 text-white rounded-lg inline-flex justify-center py-3 px-16 rounded-md font-bold text-base w-full text-sm font-semibold flex [&>*]:flex [&>*]:items-center [&>*]:gap-1 h-[50px] justify-center items-center"
+        <div
+          onClick={() => localStorage.setItem("selectedDeckId", `${deckId}`)}
+          className="w-full"
         >
-          Connect Wallet
-        </DynamicConnectButton>
+          <DynamicConnectButton
+            buttonContainerClassName="w-full"
+            buttonClassName="bg-purple-500 text-white rounded-lg inline-flex justify-center py-3 px-16 rounded-md font-bold text-base w-full text-sm font-semibold flex [&>*]:flex [&>*]:items-center [&>*]:gap-1 h-[50px] justify-center items-center"
+          >
+            Connect Wallet
+          </DynamicConnectButton>
+        </div>
 
         <Button
           onClick={onClose}


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Branched from https://github.com/gator-labs/chomp/tree/PROD-257/create-connect-wallet-state-on-campaigndetails. After @danijel-radomiljac resolves conflicts on his branch, I'll apply it here.
- Link to the Linear task https://linear.app/gator/issue/PROD-322/redirect-to-deck-after-logging-in-from-campaigns
- I am open to any suggestion. I did this in a rush a bit just to make it work for the breakpoint
- What are the steps to test that this code is working?
-  Anonymous go to the campaings page. Pick one campaign and select deck. On select connect wallet should appear. After successfully connection you should be redirected to the selected deck.
- Screen shots or recordings for UI changes

https://github.com/user-attachments/assets/95523081-62fd-4429-83b6-b3fdba6690d5

