### PR TITLE
PROD-313 added auth to admin routes

### DIFF
--- a/app/components/AuthRedirect/AuthRedirect.tsx
+++ b/app/components/AuthRedirect/AuthRedirect.tsx
@@ -1,4 +1,5 @@
 import { getJwtPayload } from "@/app/actions/jwt";
+import { getCurrentUser } from "@/app/queries/user";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -13,5 +14,12 @@ export const AuthRedirect = async () => {
     redirect(`/login?next=${encodeURIComponent(path)}`);
   }
 
+  if (jwt && path?.includes("/admin")) {
+    const currentUser = await getCurrentUser();
+    if (currentUser?.isAdmin) {
+      return null;
+    }
+    redirect("/application");
+  }
   return null;
 };

--- a/app/components/AuthRedirect/AuthRedirect.tsx
+++ b/app/components/AuthRedirect/AuthRedirect.tsx
@@ -1,5 +1,5 @@
 import { getJwtPayload } from "@/app/actions/jwt";
-import { getCurrentUser } from "@/app/queries/user";
+import { getIsUserAdmin } from "@/app/queries/user";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
@@ -15,11 +15,11 @@ export const AuthRedirect = async () => {
   }
 
   if (jwt && path?.includes("/admin")) {
-    const currentUser = await getCurrentUser();
-    if (currentUser?.isAdmin) {
-      return null;
+    const isAdmin = await getIsUserAdmin();
+
+    if (!isAdmin) {
+      redirect("/application");
     }
-    redirect("/application");
   }
   return null;
 };


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task: https://linear.app/gator/issue/PROD-313/add-auth-to-admin-routes
- What are the steps to test that this code is working?
- Login with the account that does not have the admin rights. Type the  "/admin" url path. You should not be able to access the admin dashboard. It should result in redirect to /application page (I've decided to add redirect since it was the easiest)
- Screen shots or recordings for UI changes
