### PR TITLE
PROD-337: remove enum from queries

### DIFF
--- a/app/queries/answerPercentageQuery.ts
+++ b/app/queries/answerPercentageQuery.ts
@@ -1,4 +1,4 @@
-import { AnswerStatus, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import prisma from "../services/prisma";
 
 type QuestionOptionPercentage = {
@@ -22,21 +22,21 @@ export async function answerPercentageQuery(questionOptionIds: number[]) {
                   (
                     select count(*)
                     from public."QuestionAnswer" subQa
-                    where subQa.selected = true and subQa."questionOptionId" = qo."id" and subQa."status" = ${AnswerStatus.Submitted}
+                    where subQa.selected = true and subQa."questionOptionId" = qo."id" and subQa."status" = 'Submitted'
                   ) 
                   /
                   NULLIF(
                     (
                       select count(*)
                       from public."QuestionAnswer" subQa
-                      where subQa."questionOptionId" = qo."id" and subQa."status" = ${AnswerStatus.Submitted}
+                      where subQa."questionOptionId" = qo."id" and subQa."status" = 'Submitted'
                     )
                   , 0)
                   * 100) as "firstOrderSelectedAnswerPercentage",
                 (
                   select round(avg(percentage))
                   from public."QuestionAnswer"
-                  where "questionOptionId" = qo."id" and "status" = ${AnswerStatus.Submitted}
+                  where "questionOptionId" = qo."id" and "status" = 'Submitted'
                 ) as "secondOrderAveragePercentagePicked"
               from public."QuestionOption" qo
               where qo."id" in (${Prisma.join(questionOptionIds)})

--- a/app/queries/answerPercentageQuery.ts
+++ b/app/queries/answerPercentageQuery.ts
@@ -22,21 +22,21 @@ export async function answerPercentageQuery(questionOptionIds: number[]) {
                   (
                     select count(*)
                     from public."QuestionAnswer" subQa
-                    where subQa.selected = true and subQa."questionOptionId" = qo."id" and subQa."status" = ${AnswerStatus.Submitted}::"AnswerStatus"
+                    where subQa.selected = true and subQa."questionOptionId" = qo."id" and subQa."status" = ${AnswerStatus.Submitted}
                   ) 
                   /
                   NULLIF(
                     (
                       select count(*)
                       from public."QuestionAnswer" subQa
-                      where subQa."questionOptionId" = qo."id" and subQa."status" = ${AnswerStatus.Submitted}::"AnswerStatus"
+                      where subQa."questionOptionId" = qo."id" and subQa."status" = ${AnswerStatus.Submitted}
                     )
                   , 0)
                   * 100) as "firstOrderSelectedAnswerPercentage",
                 (
                   select round(avg(percentage))
                   from public."QuestionAnswer"
-                  where "questionOptionId" = qo."id" and "status" = ${AnswerStatus.Submitted}::"AnswerStatus"
+                  where "questionOptionId" = qo."id" and "status" = ${AnswerStatus.Submitted}
                 ) as "secondOrderAveragePercentagePicked"
               from public."QuestionOption" qo
               where qo."id" in (${Prisma.join(questionOptionIds)})

--- a/app/queries/home.ts
+++ b/app/queries/home.ts
@@ -150,14 +150,15 @@ async function getNextDeckIdQuery(
 
   const filteredDecks = deckExpiringSoon.filter((deck) => deck.id !== deckId);
 
-  const campaignMatch = filteredDecks.find((deck) => deck.campaignId === campaignId);
+  const campaignMatch = filteredDecks.find(
+    (deck) => deck.campaignId === campaignId,
+  );
 
   if (campaignMatch) {
     return campaignMatch.id;
   }
 
   return filteredDecks.length > 0 ? filteredDecks[0].id : undefined;
-
 }
 
 async function queryExpiringDecks(userId: string): Promise<DeckExpiringSoon[]> {
@@ -261,7 +262,7 @@ async function queryRevealedQuestions(
       ON qo."questionId" = q."id"
   LEFT JOIN public."QuestionAnswer" qa 
       ON qa."questionOptionId" = qo."id" 
-      AND qa."userId" = ${userId} AND qa."status" = ${AnswerStatus.Submitted}::"AnswerStatus"
+      AND qa."userId" = ${userId} AND qa."status" = ${AnswerStatus.Submitted}
   WHERE
       cr1."questionId" IS NULL
       AND qa."id" IS NULL

--- a/app/queries/home.ts
+++ b/app/queries/home.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { AnswerStatus } from "@prisma/client";
 import { Decimal } from "@prisma/client/runtime/library";
 import dayjs from "dayjs";
 import { redirect } from "next/navigation";
@@ -262,7 +261,7 @@ async function queryRevealedQuestions(
       ON qo."questionId" = q."id"
   LEFT JOIN public."QuestionAnswer" qa 
       ON qa."questionOptionId" = qo."id" 
-      AND qa."userId" = ${userId} AND qa."status" = ${AnswerStatus.Submitted}
+      AND qa."userId" = ${userId} AND qa."status" = 'Submitted'
   WHERE
       cr1."questionId" IS NULL
       AND qa."id" IS NULL


### PR DESCRIPTION
Quickfix for: https://gator-labs.sentry.io/issues/5708830076/?environment=vercel-production&project=4507686429130752&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=1

Removing these enum type checks may have some performance loss issues but should prevent the breaking error.
