### PR TITLE
PROD-339 added new view

### DIFF
--- a/app/_reactQuery/useInfiniteQuestionsHistory.ts
+++ b/app/_reactQuery/useInfiniteQuestionsHistory.ts
@@ -2,7 +2,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef } from "react";
 import { getQuestionsHistory } from "../actions/history";
 
-export default function useInfiniteQuestionsHistory() {
+export default function useInfiniteQuestionsHistory(deckId?: string) {
   const observer = useRef<IntersectionObserver>();
 
   const {
@@ -15,7 +15,7 @@ export default function useInfiniteQuestionsHistory() {
     ...rest
   } = useInfiniteQuery({
     queryKey: ["questions-history"],
-    queryFn: ({ pageParam }) => getQuestionsHistory({ pageParam }),
+    queryFn: ({ pageParam }) => getQuestionsHistory({ pageParam, deckId }),
     initialPageParam: 1,
     getNextPageParam: (lastPage, allPages) => {
       return lastPage.length ? allPages.length + 1 : undefined;

--- a/app/actions/history.ts
+++ b/app/actions/history.ts
@@ -22,8 +22,10 @@ export const getHistoryDecks = async () => {
 
 export const getQuestionsHistory = async ({
   pageParam,
+  deckId,
 }: {
   pageParam: number;
+  deckId?: string;
 }): Promise<QuestionHistory[]> => {
   const payload = await getJwtPayload();
 
@@ -31,7 +33,7 @@ export const getQuestionsHistory = async ({
     return [];
   }
 
-  return getQuestionsHistoryQuery(payload.sub, PAGE_SIZE, pageParam);
+  return getQuestionsHistoryQuery(payload.sub, PAGE_SIZE, pageParam, deckId);
 };
 
 export async function getTotalClaimableRewards() {
@@ -52,6 +54,47 @@ export async function getTotalClaimableRewards() {
     },
     include: {
       question: true,
+    },
+  });
+
+  return {
+    questions: res.map((q) => q.question),
+    totalClaimableRewards: res.reduce(
+      (acc, curr) => acc + (curr?.rewardTokenAmount?.toNumber() ?? 0),
+      0,
+    ),
+  };
+}
+
+export async function getDeckTotalClaimableRewards(deckId: number) {
+  const payload = await getJwtPayload();
+
+  if (!payload) {
+    return;
+  }
+
+  const res = await prisma.chompResult.findMany({
+    where: {
+      userId: payload.sub,
+      result: "Revealed",
+      questionId: { not: null },
+      rewardTokenAmount: {
+        gt: 0,
+      },
+    },
+    include: {
+      question: {
+        include: {
+          deckQuestions: {
+            where: {
+              deckId,
+            },
+            select: {
+              deckId: true,
+            },
+          },
+        },
+      },
     },
   });
 

--- a/app/application/decks/[id]/page.tsx
+++ b/app/application/decks/[id]/page.tsx
@@ -1,5 +1,6 @@
 import ComingSoonDeck from "@/app/components/ComingSoonDeck/ComingSoonDeck";
 import { NoQuestionsCard } from "@/app/components/NoQuestionsCard/NoQuestionsCard";
+import RevealDeck from "@/app/components/RevealDeck/RevealDeck";
 import { getCampaignImage } from "@/app/queries/campaign";
 import { getDeckQuestionsForAnswerById } from "@/app/queries/deck";
 import { getNextDeckId } from "@/app/queries/home";
@@ -13,28 +14,41 @@ export default async function Page({ params: { id } }: PageProps) {
   const currentDeckId = Number(id);
   const deck = await getDeckQuestionsForAnswerById(currentDeckId);
 
-  const campaignId = Number(deck?.campaignId) || null
+  const campaignId = Number(deck?.campaignId) || null;
 
-  const campaignData = campaignId ? await getCampaignImage(campaignId) : null
+  const campaignData = campaignId ? await getCampaignImage(campaignId) : null;
 
   const nextDeckId = await getNextDeckId(currentDeckId, campaignId);
 
   return (
     <div className="h-full pt-3 pb-4">
-      {deck?.questions.length === 0 || deck === null ? (
+      {deck === null ? (
         <NoQuestionsCard variant={"regular-deck"} nextDeckId={nextDeckId} />
-      ) : deck?.questions && deck?.questions?.length > 0 && deck?.deckInfo ? (
+      ) : deck.revealAtDate &&
+        deck.revealAtDate < new Date() &&
+        deck.deckInfo ? (
+        <RevealDeck
+          deckId={currentDeckId}
+          deckTitle={deck.deckInfo.heading}
+          deckDescription={deck.deckInfo.description}
+          deckFooter={deck.deckInfo.footer}
+          deckImage={deck.deckInfo.imageUrl || campaignData?.image}
+          numberOfQuestions={deck.totalDeckQuestions}
+        />
+      ) : deck.questions?.length > 0 && deck.deckInfo ? (
         <DeckScreen
           currentDeckId={deck.id}
           nextDeckId={nextDeckId}
           questions={deck.questions}
-          campaignImage={campaignData?.image ?? ''}
+          campaignImage={campaignData?.image ?? ""}
           deckInfo={{
             ...deck.deckInfo!,
             totalNumberOfQuestions: deck.questions.length,
           }}
           numberOfUserAnswers={deck.numberOfUserAnswers!}
         />
+      ) : deck.questions.length === 0 ? (
+        <NoQuestionsCard variant={"regular-deck"} nextDeckId={nextDeckId} />
       ) : (
         <ComingSoonDeck deckName={deck?.name} />
       )}

--- a/app/components/CampaignDeckCard/CampaignDeckCard.tsx
+++ b/app/components/CampaignDeckCard/CampaignDeckCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { getTimeString } from "@/app/utils/dateUtils";
-import { getDeckPath, HISTORY_PATH } from "@/lib/urls";
+import { getDeckPath } from "@/lib/urls";
 import { cn } from "@/lib/utils";
 import { ChompResult, Question, ResultType } from "@prisma/client";
 import { isAfter } from "date-fns";
@@ -147,7 +147,7 @@ const CampaignDeckCard = ({
     chompResults.length === deckQuestions.length &&
     (claimedAmount === 0 || claimableAmount > 0);
 
-  let linkPath = isDeckReadyToReveal ? HISTORY_PATH : getDeckPath(deckId);
+  let linkPath = getDeckPath(deckId);
   if (!userId) linkPath = `/login?next=${encodeURIComponent(linkPath)}`;
 
   return (

--- a/app/components/History/History.tsx
+++ b/app/components/History/History.tsx
@@ -5,9 +5,13 @@ import HistoryListSkeleton from "../HistoryListSkeleton/HistoryListSkeleton";
 import QuestionRowCard from "../QuestionRowCard/QuestionRowCard";
 import Skeleton from "../Skeleton/Skeleton";
 
-export default function History() {
+interface HistoryProps {
+  deckId?: string;
+}
+
+export default function History({ deckId }: HistoryProps) {
   const { data, isFetchingNextPage, lastElementRef, isLoading } =
-    useInfiniteQuestionsHistory();
+    useInfiniteQuestionsHistory(deckId);
 
   if (isLoading) return <HistoryListSkeleton />;
 

--- a/app/components/RevealDeck/RevealDeck.tsx
+++ b/app/components/RevealDeck/RevealDeck.tsx
@@ -1,0 +1,61 @@
+import { getDeckTotalClaimableRewards } from "@/app/actions/history";
+import { getAllDeckQuestionsReadyForReveal } from "@/app/queries/history";
+import Image from "next/image";
+import chompGraphicImage from "../../../public/images/chomp-graphic.png";
+import BackButton from "../BackButton/BackButton";
+import History from "../History/History";
+import HistoryHeader from "../HistoryHeader/HistoryHeader";
+
+interface RevealDeckProps {
+  deckId: number;
+  deckTitle: string;
+  deckDescription: string | null;
+  deckFooter: string | null;
+  numberOfQuestions: number;
+  deckImage?: string;
+}
+
+const RevealDeck = async ({
+  deckId,
+  deckTitle,
+  deckDescription,
+  deckFooter,
+  numberOfQuestions,
+  deckImage = chompGraphicImage.src,
+}: RevealDeckProps) => {
+  console.log("deckTitle", deckTitle);
+  const [revealableQuestions, totalClaimableRewards] = await Promise.all([
+    getAllDeckQuestionsReadyForReveal(deckId),
+    getDeckTotalClaimableRewards(deckId),
+  ]);
+  return (
+    <div className="pt-4 flex flex-col gap-8 overflow-hidden w-full max-w-lg mx-auto px-4">
+      <BackButton />
+      <div className="p-4 bg-gray-850 flex gap-4">
+        <div className="relative w-[100.5px] h-[100.5px]">
+          <Image
+            src={deckImage}
+            fill
+            alt={deckTitle}
+            className="object-cover"
+          />
+        </div>
+        <div className="flex flex-col">
+          <h1 className="text-base mb-3">{deckTitle}</h1>
+          <p className="text-xs mb-6">
+            {deckDescription ? `${deckDescription}, ` : ""}
+          </p>
+          <p>{deckFooter ? `${deckFooter}, ` : ""}</p>
+          <p>{numberOfQuestions} cards</p>
+        </div>
+      </div>
+      <HistoryHeader
+        revealableQuestions={revealableQuestions}
+        totalClaimableRewards={totalClaimableRewards}
+      />
+      <History deckId={`${deckId}`} />
+    </div>
+  );
+};
+
+export default RevealDeck;

--- a/app/queries/deck.ts
+++ b/app/queries/deck.ts
@@ -164,12 +164,20 @@ export async function getDeckQuestionsForAnswerById(deckId: number) {
     return null;
   }
 
+  const totalDeckQuestions = await prisma.deckQuestion.count({
+    where: {
+      deckId: deckId,
+    },
+  });
+
   if (!!deck.activeFromDate && isAfter(deck.activeFromDate, new Date())) {
     return {
       questions: deck?.deckQuestions,
       id: deck.id,
       date: deck.date,
       name: deck.deck,
+      totalDeckQuestions,
+      revealAtDate: deck.revealAtDate,
     };
   } else if (
     deck.deckQuestions.some((dq) =>
@@ -180,7 +188,15 @@ export async function getDeckQuestionsForAnswerById(deckId: number) {
       questions: [],
       id: deck.id,
       date: deck.date,
-      campaignId: deck.campaignId
+      revealAtDate: deck.revealAtDate,
+      campaignId: deck.campaignId,
+      totalDeckQuestions,
+      deckInfo: {
+        heading: deck.heading || deck.deck,
+        description: deck.description,
+        imageUrl: deck.imageUrl,
+        footer: deck.footer,
+      },
     };
   }
 
@@ -190,7 +206,9 @@ export async function getDeckQuestionsForAnswerById(deckId: number) {
     questions,
     id: deck.id,
     date: deck.date,
+    revealAtDate: deck.revealAtDate,
     campaignId: deck.campaignId,
+    totalDeckQuestions,
     numberOfUserAnswers: deck.deckQuestions.flatMap((dq) =>
       dq.question.questionOptions.flatMap((qo) => qo.questionAnswers),
     ).length,

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -134,9 +134,9 @@ export async function getQuestionsHistoryQuery(
 `;
 
   let finalQuery = baseQuery;
-  if (process.env.NEXT_PUBLIC_ENVIRONMENT === "staging") {
-    finalQuery += havingClause;
-  }
+  // if (process.env.NEXT_PUBLIC_ENVIRONMENT === "staging") {
+  //   finalQuery += havingClause;
+  // }
   finalQuery += endQuery;
 
   const historyResult: QuestionHistory[] =

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -65,8 +65,11 @@ export async function getQuestionsHistoryQuery(
   userId: string,
   pageSize: number,
   currentPage: number,
+  deckId?: string,
 ): Promise<QuestionHistory[]> {
   const offset = (currentPage - 1) * pageSize;
+
+  const deckHistoryCondition: string = `AND dq."deckId" = ${deckId}`;
 
   const baseQuery = `
   SELECT 
@@ -108,8 +111,9 @@ export async function getQuestionsHistoryQuery(
   LEFT JOIN 
     public."ChompResult" cr ON cr."questionId" = q.id AND cr."userId" = '${userId}' AND cr."questionId" IS NOT NULL
   FULL JOIN public."Campaign" c on c.id = q."campaignId"
+  JOIN public."DeckQuestion" dq ON dq."questionId" = q.id
   WHERE 
-    q."revealAtDate" IS NOT NULL
+    q."revealAtDate" IS NOT NULL ${deckId ? deckHistoryCondition : ""}
   GROUP BY 
     q.id, cr."rewardTokenAmount", cr."burnTransactionSignature", c."image"
 `;
@@ -194,6 +198,67 @@ WHERE
     AND q."revealAtDate" < NOW()
     AND qa.selected = TRUE
     AND qa."userId" = '${userId}';
+	`,
+  );
+
+  return questions.filter(
+    (question) =>
+      question.answerCount && question.answerCount >= MINIMAL_ANSWER_COUNT,
+  );
+}
+
+export async function getAllDeckQuestionsReadyForReveal(
+  deckId: number,
+): Promise<{ id: number; revealTokenAmount: number; question: string }[]> {
+  const payload = await authGuard();
+
+  const userId = payload.sub;
+
+  const questions = await prisma.$queryRawUnsafe<
+    {
+      id: number;
+      revealTokenAmount: number;
+      answerCount: number;
+      question: string;
+    }[]
+  >(
+    `
+		SELECT 
+    q.id,
+    q.question,
+    CASE 
+        WHEN cr."transactionStatus" = 'Completed' OR cr."transactionStatus" = 'Pending' THEN 0
+        ELSE q."revealTokenAmount"
+    END AS "revealTokenAmount",
+    (
+        SELECT
+            COUNT(DISTINCT CONCAT(qa."userId", qo."questionId"))
+        FROM 
+            public."QuestionOption" qo
+        JOIN 
+            public."QuestionAnswer" qa ON qa."questionOptionId" = qo."id"
+        WHERE 
+            qo."questionId" = q."id"
+    ) AS "answerCount",
+     dc."deckId" as "deckId"
+FROM 
+    public."Question" q
+LEFT JOIN 
+    "ChompResult" cr ON cr."questionId" = q.id
+    AND cr."userId" = '${userId}'
+    AND cr."transactionStatus" IN ('Completed', 'Pending')
+JOIN 
+    "QuestionOption" qo ON q.id = qo."questionId"
+JOIN 
+    "QuestionAnswer" qa ON qo.id = qa."questionOptionId"
+JOIN "DeckQuestion" dc ON q.id = dc."questionId"
+WHERE 
+    (cr."transactionStatus" IS NULL OR cr."transactionStatus" != 'Completed')
+    AND q."revealAtDate" IS NOT NULL
+    AND q."revealAtDate" < NOW()
+    AND qa.selected = TRUE
+    AND qa."userId" = '${userId}'
+    AND dc."deckId" = ${deckId};
 	`,
   );
 

--- a/app/screens/DeckScreens/DeckScreen.tsx
+++ b/app/screens/DeckScreens/DeckScreen.tsx
@@ -1,13 +1,13 @@
 "use client";
-import { Button } from "@/app/components/ui/button";
 import { Deck, Question } from "@/app/components/Deck/Deck";
-import { useRouter } from "next-nprogress-bar";
-import { useState } from "react";
-import { CircleArrowRight } from 'lucide-react';
 import PreviewDeckCard from "@/app/components/PreviewDeckCard";
 import Stepper from "@/app/components/Stepper/Stepper";
+import { Button } from "@/app/components/ui/button";
 import { MIX_PANEL_EVENTS, MIX_PANEL_METADATA } from "@/app/constants/mixpanel";
 import sendToMixpanel from "@/lib/mixpanel";
+import { CircleArrowRight } from "lucide-react";
+import { useRouter } from "next-nprogress-bar";
+import { useState } from "react";
 
 type DeckScreenProps = {
   deckInfo: {
@@ -16,6 +16,7 @@ type DeckScreenProps = {
     footer: string | null;
     imageUrl: string | null;
     totalNumberOfQuestions: number;
+    revealAtDate?: Date | null;
   };
   questions: Question[];
   currentDeckId: number;
@@ -65,10 +66,7 @@ const DeckScreen = ({
               Begin Deck
               <CircleArrowRight />
             </Button>
-            <Button
-              variant="outline"
-              onClick={() => router.back()}
-            >
+            <Button variant="outline" onClick={() => router.back()}>
               Back
             </Button>
           </div>


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task https://linear.app/gator/issue/PROD-339/create-new-deck-view-for-ready-to-reveal-decks
  I did ad hock changes. Strongly suggest code improvement for this part when we agree on the logic behind. Reused history component and adapted queries
- What are the steps to test that this code is working?
  Open the deck that is ready to reveal and you should see this screen.
- Screen shots or recordings for UI changes
<img width="1275" alt="Screenshot 2024-09-22 at 23 08 21" src="https://github.com/user-attachments/assets/0578d898-6771-466d-a88f-b4eaf6ce0f12">

