### PR TITLE
 PROD-348/breakpoint-nft-reveal-issues 

### DIFF
--- a/app/actions/chompResult.ts
+++ b/app/actions/chompResult.ts
@@ -158,6 +158,20 @@ export async function revealQuestions(
       },
     });
 
+    let revealNftId = null;
+
+    if (isRevealedWithNft) {
+      const revealNft = await prisma.revealNft.create({
+        data: {
+          userId: payload.sub,
+          nftType,
+          nftId: nftAddress,
+        },
+      });
+
+      revealNftId = revealNft.nftId;
+    }
+
     await tx.chompResult.createMany({
       data: [
         ...questionRewards.map((questionReward) => ({
@@ -167,7 +181,7 @@ export async function revealQuestions(
           burnTransactionSignature: burnTx,
           rewardTokenAmount: questionReward.rewardAmount,
           transactionStatus: TransactionStatus.Completed,
-          revealNftId: isRevealedWithNft ? nftAddress : null,
+          revealNftId,
         })),
       ],
     });

--- a/app/actions/chompResult.ts
+++ b/app/actions/chompResult.ts
@@ -114,10 +114,11 @@ export async function revealQuestions(
     throw new Error("No revealable questions available");
   }
 
+  const isRevealedWithNft =
+    nftAddress && nftType && (await checkNft(nftAddress, nftType));
+
   const bonkToBurn = revealableQuestions
-    .slice(
-      nftAddress && nftType && (await checkNft(nftAddress, nftType)) ? 1 : 0,
-    ) // skip bonk burn for first question if nft is supplied
+    .slice(isRevealedWithNft ? 1 : 0) // skip bonk burn for first question if nft is supplied
     .reduce((acc, cur) => acc + cur.revealTokenAmount, 0);
 
   if (bonkToBurn > 0) {
@@ -166,6 +167,7 @@ export async function revealQuestions(
           burnTransactionSignature: burnTx,
           rewardTokenAmount: questionReward.rewardAmount,
           transactionStatus: TransactionStatus.Completed,
+          revealNftId: isRevealedWithNft ? nftAddress : null,
         })),
       ],
     });

--- a/app/actions/revealNft.ts
+++ b/app/actions/revealNft.ts
@@ -125,8 +125,6 @@ export const checkNft = async (nftAddress: string, nftType: NftType) => {
     return null;
   }
 
-  await createRevealNft(nftAddress, payload.sub, nftType);
-
   return true;
 };
 

--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -299,6 +299,7 @@ const RevealAnswerPage = async ({ params }: Props) => {
           questionResponse.chompResults[0]?.burnTransactionSignature || ""
         }
         questions={[questionResponse.question]}
+        revealNftId={questionResponse.chompResults[0].revealNftId}
       />
       {sendTransactionSignature && (
         <a

--- a/app/components/ClaimButton/ClaimButton.tsx
+++ b/app/components/ClaimButton/ClaimButton.tsx
@@ -26,6 +26,7 @@ interface ClaimButtonProps {
   questionIds: number[];
   questions?: string[];
   transactionHash?: string;
+  revealNftId?: string | null;
 }
 
 const ClaimButton = ({
@@ -36,6 +37,7 @@ const ClaimButton = ({
   questionIds,
   transactionHash,
   questions,
+  revealNftId,
 }: ClaimButtonProps) => {
   const { fire } = useConfetti();
   const { promiseToast, errorToast } = useToast();
@@ -54,12 +56,14 @@ const ClaimButton = ({
         [MIX_PANEL_METADATA.REVEAL_TYPE]: REVEAL_TYPE.SINGLE,
       });
 
-      const tx = await CONNECTION.getTransaction(transactionHash!, {
-        commitment: "confirmed",
-        maxSupportedTransactionVersion: 0,
-      });
+      if (!revealNftId) {
+        const tx = await CONNECTION.getTransaction(transactionHash!, {
+          commitment: "confirmed",
+          maxSupportedTransactionVersion: 0,
+        });
 
-      if (!tx) return errorToast("Cannot get transaction");
+        if (!tx) return errorToast("Cannot get transaction");
+      }
 
       promiseToast(claimQuestions(questionIds), {
         loading: "Claiming your rewards...",

--- a/app/hooks/useReveal.ts
+++ b/app/hooks/useReveal.ts
@@ -346,8 +346,8 @@ export function useReveal({ wallet, address, bonkBalance }: UseRevealProps) {
       } else {
         await reveal!.reveal({
           burnTx: signature,
-          nftAddress: revealNft!.id,
-          nftType: revealNft!.type,
+          nftAddress: ignoreNft ? "" : revealNft!.id,
+          nftType: ignoreNft ? undefined : revealNft!.type,
         });
       }
 

--- a/app/queries/question.ts
+++ b/app/queries/question.ts
@@ -245,6 +245,9 @@ export async function getQuestionWithUserAnswer(questionId: number) {
         where: {
           userId,
         },
+        include: {
+          revealNft: true,
+        },
       },
     },
   });

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "dev:mc-obj": "dotenv -c -- ts-node -P tsconfig.scripts.json scripts/objective-multiple-choice-questions.ts",
     "dev:binary-obj": "dotenv -c -- ts-node -P tsconfig.scripts.json scripts/objective-binary-questions.ts",
     "dev:campaign-leaderboard": "dotenv -c -- ts-node -P tsconfig.scripts.json scripts/campaign-leaderboard.ts",
+    "dev:reveal-nft": "dotenv -c -- ts-node -P tsconfig.scripts.json scripts/reveal-nft.ts",
     "dev:obj-question": "dotenv -c -- ts-node scripts/CreateObjectiveWithAnswers.ts",
     "dev:philippines-deck": "dotenv -c -- ts-node -P tsconfig.scripts.json scripts/philippines-deck.ts",
     "dev:restore-db": "dotenv -c -- ts-node scripts/restore-database.ts",

--- a/prisma/migrations/20240926080510_add_reveal_nft_id_to_chomp_result/migration.sql
+++ b/prisma/migrations/20240926080510_add_reveal_nft_id_to_chomp_result/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[revealNftId]` on the table `ChompResult` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "ChompResult" ADD COLUMN     "revealNftId" TEXT;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChompResult_revealNftId_key" ON "ChompResult"("revealNftId");
+
+-- AddForeignKey
+ALTER TABLE "ChompResult" ADD CONSTRAINT "ChompResult_revealNftId_fkey" FOREIGN KEY ("revealNftId") REFERENCES "RevealNft"("nftId") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -170,6 +170,9 @@ model ChompResult {
   updatedAt                DateTime          @default(now()) @updatedAt
   transactionStatus        TransactionStatus
 
+  revealNftId String?    @unique
+  revealNft   RevealNft? @relation(fields: [revealNftId], references: [nftId])
+
   @@unique([userId, questionId])
 }
 
@@ -211,6 +214,8 @@ model RevealNft {
   createdAt DateTime @default(now())
   updatedAt DateTime @default(now()) @updatedAt
   nftType   NftType
+
+  chompResult ChompResult? @relation
 
   @@unique([nftId, userId])
 }

--- a/scripts/reveal-nft.ts
+++ b/scripts/reveal-nft.ts
@@ -1,0 +1,58 @@
+const { v4: uuidv4 } = require("uuid");
+const path = require("path");
+import { PrismaClient } from "@prisma/client";
+
+require("dotenv").config({
+  path: path.resolve(__dirname, "../.env.local"),
+});
+
+console.log("Loaded environment variables:");
+console.log("DATABASE_PRISMA_URL:", process.env.DATABASE_PRISMA_URL);
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const chompyAroundTheWorldNfts = await prisma.revealNft.findMany({
+    where: {
+      nftType: "ChompyAroundTheWorld",
+    },
+    orderBy: {
+      createdAt: "desc",
+    },
+  });
+
+  for (const chompyAroundTheWorldNft of chompyAroundTheWorldNfts) {
+    const chompResult = await prisma.chompResult.findFirst({
+      where: {
+        burnTransactionSignature: null,
+        rewardTokenAmount: {
+          gt: 0,
+        },
+        userId: chompyAroundTheWorldNft.userId,
+        createdAt: {
+          gt: chompyAroundTheWorldNft.createdAt,
+        },
+      },
+    });
+
+    if (!!chompResult?.id)
+      await prisma.chompResult.update({
+        data: {
+          revealNftId: chompyAroundTheWorldNft.nftId,
+        },
+        where: {
+          id: chompResult.id,
+        },
+      });
+  }
+}
+
+main()
+  .then(async () => {
+    await prisma.$disconnect();
+  })
+  .catch(async (e) => {
+    console.error(e);
+    await prisma.$disconnect();
+    process.exit(1);
+  });


### PR DESCRIPTION
@marvinmarnold there was a missing relation from ChompResult table to RevealNft table. Currently I set it as one to many relation, but it needs to be one to one. I did that because default value in one to one relation cannot be null, but I will fix that after we run a script called: reveal-nft.ts

That script will connect records from RevealNft table to ChompResult table. 