### PR TITLE
PROD-316 Catch dynamic related issue in reveal

### DIFF
--- a/app/utils/error.ts
+++ b/app/utils/error.ts
@@ -25,6 +25,13 @@ export class RevealError extends Error {
   }
 }
 
+export class DynamicRevealError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "DynamicRevealError";
+  }
+}
+
 export class AnswerError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);


### PR DESCRIPTION
- Description
Add try catch in Reveal hook to narrow down specific errors in Sentry and trace a reason behind the following issue:
> An error occurred in the Server Components render. The specific message is omitted in production builds to avoid leaking sensitive details. A digest property is included on this error instance which may provide additional details about the nature of ...
- What are the steps to test that this code is working?
Verify next iteration of reveal issues in Sentry Dashboard
- Screen shots or recordings for UI changes
NA