### PR TITLE
PROD-346 Remove share & earn CTA

### DIFF
--- a/app/components/NoQuestionsCard/NoQuestionsCard.tsx
+++ b/app/components/NoQuestionsCard/NoQuestionsCard.tsx
@@ -46,19 +46,8 @@ export function NoQuestionsCard({
           style={{ zIndex: 1 }}
         />
       </div>
-      <Button
-        onClick={() => {
-          sendToMixpanel(MIX_PANEL_EVENTS.SHARE_EARN_URL);
-          window.open(process.env.NEXT_PUBLIC_REWARD_TASKON_URL, "_blank");
-        }}
-        className="text-[14px] gap-2"
-      >
-        Share & Earn More
-        <Share2 />
-      </Button>
       {nextDeckId ? (
         <Button
-          variant="outline"
           className="text-[14px] gap-2"
           onClick={() => {
             router.replace(`/application/decks/${nextDeckId}`);
@@ -69,7 +58,6 @@ export function NoQuestionsCard({
         </Button>
       ) : (
         <Button
-          variant="outline"
           className="text-[14px] gap-2"
           onClick={() => {
             router.replace("/application");


### PR DESCRIPTION
- Description
Removes the Share & Earn (TaskOn) CTA and make the secondary button (Next deck, Go home) primary

- What are the steps to test that this code is working?
Finish one deck to see the changes

- Screen shots or recordings for UI changes
![Screenshot 2024-09-26 at 10 16 46 PM](https://github.com/user-attachments/assets/72beb7b6-e9d8-4095-80c7-2cce370473e8)
