### PR TITLE
PROD-353 fixed image size

### DIFF
--- a/app/components/RevealDeck/RevealDeck.tsx
+++ b/app/components/RevealDeck/RevealDeck.tsx
@@ -31,13 +31,15 @@ const RevealDeck = async ({
     <div className="pt-4 flex flex-col gap-8 overflow-hidden w-full max-w-lg mx-auto px-4">
       <BackButton />
       <div className="p-4 bg-gray-850 flex gap-4">
-        <div className="relative w-[100.5px] h-[100.5px]">
-          <Image
-            src={deckImage}
-            fill
-            alt={deckTitle}
-            className="object-cover"
-          />
+        <div>
+          <div className="relative w-[100.5px] h-[100.5px]">
+            <Image
+              src={deckImage}
+              fill
+              alt={deckTitle}
+              className="object-cover"
+            />
+          </div>
         </div>
         <div className="flex flex-col">
           <h1 className="text-base mb-3">{deckTitle}</h1>


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the task https://linear.app/gator/issue/PROD-353/deck-page-image-dimensions-does-not-match-campaign-page
- What are the steps to test that this code is working?
- Screen shots or recordings for UI changes
[Before]
![Screenshot 2024-09-30 at 19 41 17](https://github.com/user-attachments/assets/50cb9df5-18f1-40d4-93ea-61f53503c6d1) 
->
[After]
![Screenshot 2024-09-30 at 19 40 23](https://github.com/user-attachments/assets/f5eead31-a36a-4658-aaec-68669aa7bc20)

