### PR TITLE
PROD-341: fix login pop up stacks

### DIFF
--- a/app/components/LoginPopUp/LoginPopUp.tsx
+++ b/app/components/LoginPopUp/LoginPopUp.tsx
@@ -21,7 +21,7 @@ type LoginPopUpProps = {
 
 const LoginPopUp = ({ isOpen, onClose, userId, deckId }: LoginPopUpProps) => {
   const { authToken, awaitingSignatureState } = useDynamicContext();
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     if(localStorage.getItem("selectedDeckId")) {

--- a/app/components/StackDeckCard/StackDeckCard.tsx
+++ b/app/components/StackDeckCard/StackDeckCard.tsx
@@ -175,7 +175,9 @@ const StackDeckCard = ({
       />
       <Wrapper
         onClick={() => {
-          if (buttonText === "Reveal results") {
+          if (!userId) {
+            setIsLoginModalOpen(true);
+          } else if (buttonText === "Reveal results") {
             openRevealModal({
               reveal: async ({ burnTx, revealQuestionIds }: RevealProps) => {
                 await revealQuestions(revealQuestionIds!, burnTx);
@@ -191,7 +193,6 @@ const StackDeckCard = ({
               dialogLabel: "Reveal deck",
             });
           }
-
           if (buttonText === "Claim your reward") {
             openClaimModal({
               description: "Would you like to claim all rewards in this deck?",


### PR DESCRIPTION
- Description
Revert back to #550 and fix loader screen issue on mobile if stack has more decks

The LoginPopup was causing issues on the stack page for mobile screens, so you temporarily commented it out during Breakpoint. This PR resolves the issue by disabling an initial isLoading state in LoginPopup and reverting the original behavior of triggering on deck click.

- What are the steps to test that this code is working?
Open Engima stack in mobile to test the consistency

- Screen shots or recordings for UI changes
NA