### PR TITLE
PROD-350 fixed condition for claim

### DIFF
--- a/app/actions/history.ts
+++ b/app/actions/history.ts
@@ -81,6 +81,15 @@ export async function getDeckTotalClaimableRewards(deckId: number) {
       rewardTokenAmount: {
         gt: 0,
       },
+      AND: {
+        question: {
+          deckQuestions: {
+            some: {
+              deckId,
+            },
+          },
+        },
+      },
     },
     include: {
       question: {


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the task: https://linear.app/gator/issue/PROD-350/deck-specific-claim-all-doesnt-match-questions
- What are the steps to test that this code is working?
  Answer and reveal question for some deck that is related to some stack. Claim reward amount for that question should be claimable just from that deck reveal page, not from the other deck (History could and should be)
- Screen shots or recordings for UI changes
<img width="537" alt="Screenshot 2024-10-02 at 19 03 57" src="https://github.com/user-attachments/assets/251438a7-98d0-4322-9a99-431b20b1e826">
<img width="537" alt="Screenshot 2024-10-02 at 19 04 19" src="https://github.com/user-attachments/assets/e55a7ecb-eff8-4fb3-b9fa-d28a35c5021f">
<img width="537" alt="Screenshot 2024-10-02 at 19 04 37" src="https://github.com/user-attachments/assets/f49a4b35-b17c-481c-b162-cb4aac118b74">
