### PR TITLE
PROD-362 Ignore sentry error

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -4,4 +4,5 @@ export const ignoreErrors = [
   "[PhantomRedirect] getSession called, but required input 'encryptionSecretKey' not found in local storage",
   "User rejected the request.",
   "Talisman extension has not been configured yet. Please continue with onboarding.",
+  "Cannot destructure property 'address' of '(intermediate value)' as it is undefined.",
 ];


### PR DESCRIPTION
- Description
`Error: Cannot destructure property 'address' of '(intermediate value)' as it is undefined.` doesn't impact the user experience. It appears to be related to a browser extension, which is beyond our control. Ignoring this sentry error would be better option unless it starts causing any real issues.
- What are the steps to test that this code is working?
Monitor sentry board for similar errors
- Screen shots or recordings for UI changes
NA