### PR TITLE
PROD-358: Enable captureConsole Integration Sentry

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -19,5 +19,9 @@ Sentry.init({
   ignoreErrors: ignoreErrors,
 
   // Enables capturing all console API calls and redirects them to Sentry using the captureException
-  integrations: [Sentry.captureConsoleIntegration()],
+  integrations: [
+    Sentry.captureConsoleIntegration({
+      levels: ["error"],
+    }),
+  ],
 });

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -17,4 +17,7 @@ Sentry.init({
   // Uncomment the line below to enable Spotlight (https://spotlightjs.com)
   // spotlight: process.env.NODE_ENV === 'development',
   ignoreErrors: ignoreErrors,
+
+  // Enables capturing all console API calls and redirects them to Sentry using the captureException
+  integrations: [Sentry.captureConsoleIntegration()],
 });


### PR DESCRIPTION
- Description
Load Failed errors occur when Fetch API calls fail. It usually happens on Apple devices. Following the below documentation, I have added captureConsole integration to get additional context for such errors.
https://sentry.io/answers/load-failed-javascript/
- What are the steps to test that this code is working?
Sentry events will also show console logs of requests being made
- Screen shots or recordings for UI changes
NA
