### PR TITLE
PROD-383: Sentry invariant expected app router to be mounted

### DIFF
--- a/app/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
+"use client"
 import * as Sentry from "@sentry/nextjs";
 import { ArrowLeft, RefreshCw } from "lucide-react";
-import { useRouter } from "next-nprogress-bar";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect } from "react";
@@ -8,8 +8,6 @@ import { Button } from "../ui/button";
 import { HOME_PATH } from "@/lib/urls";
 
 function ErrorBoundary({ error, reset }: { error: Error; reset: () => void }) {
-  const router = useRouter();
-
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -55,15 +53,14 @@ function ErrorBoundary({ error, reset }: { error: Error; reset: () => void }) {
       </div>
 
       <div className="flex flex-col mt-auto gap-y-[16px] mb-[16px]">
-        <Link href={HOME_PATH}>
-          <Button
-            variant="outline"
-            className="text-[14px] gap-2"
-          >
-            <ArrowLeft />
-            Return home
-          </Button>
-        </Link>
+        <Button
+          variant="outline"
+          className="text-[14px] gap-2"
+          onClick={() => window.location.href = '/failed'}
+        >
+          <ArrowLeft />
+          Return home
+        </Button>
       </div>
     </div>
   );

--- a/app/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/app/components/ErrorBoundary/ErrorBoundary.tsx
@@ -56,7 +56,7 @@ function ErrorBoundary({ error, reset }: { error: Error; reset: () => void }) {
         <Button
           variant="outline"
           className="text-[14px] gap-2"
-          onClick={() => window.location.href = '/failed'}
+          onClick={() => window.location.href = HOME_PATH}
         >
           <ArrowLeft />
           Return home

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,7 +1,7 @@
 "use client";
 import ErrorBoundary from "./components/ErrorBoundary/ErrorBoundary";
 
-export default function GlobalError({
+export default function Error({
   error,
   reset,
 }: {

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,6 +1,7 @@
 "use client";
 import ErrorBoundary from "./components/ErrorBoundary/ErrorBoundary";
 
+// avoid using useRouter in the global error boundaries as they don't have nextjs context.
 export default function GlobalError({
   error,
   reset,


### PR DESCRIPTION
- Description
Previously because we had useRouter in our error boundary and global error file catches the error from Root Layout which is out of next context causing this error sentry invariant expected app router to be mounted.
- What are the steps to test that this code is working?
Rendering global-error and error boundary in production properly.
- Screen shots or recordings for UI changes
N/A