### PR TITLE
fix: await tracking and ignore errors

### DIFF
--- a/lib/trackEvent.ts
+++ b/lib/trackEvent.ts
@@ -16,16 +16,20 @@ const trackEvent = async (
     ...additionalProperties,
   };
 
-  fetch("/api/mixpanel", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      event: eventName,
-      properties: properties,
-    }),
-  });
+  try {
+    await fetch("/api/mixpanel", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        event: eventName,
+        properties: properties,
+      }),
+    });
+  } catch (e) {
+    console.error("Unable to track event", e);
+  }
 };
 
 export default trackEvent;


### PR DESCRIPTION
- Ignore tracking errors (but logging will send to Sentry)
- await for tracking to finish, to ensure it's not accidentally skipped