### PR TITLE
PROD-414 Add DeckClicked mixpanel event

### DIFF
--- a/app/components/HomeFeedDeckCard/HomeFeedDeckCard.tsx
+++ b/app/components/HomeFeedDeckCard/HomeFeedDeckCard.tsx
@@ -5,6 +5,8 @@ import Image from "next/image";
 import { DeckGraphic } from "../Graphics/DeckGraphic";
 import CardsIcon from "../Icons/CardsIcon";
 import { RevealCardInfo } from "../RevealCardInfo/RevealCardInfo";
+import trackEvent from "@/lib/trackEvent";
+import { TRACKING_EVENTS, TRACKING_METADATA } from "@/app/constants/tracking";
 
 type StatusUnion = "chomped" | "new" | "continue";
 type HomeFeedDeckCardProps = {
@@ -44,6 +46,13 @@ export function HomeFeedDeckCard({
   return (
     <a
       href={date ? `/daily-deck` : `application/decks/${deckId}`}
+      onClick={() => {
+        trackEvent(TRACKING_EVENTS.DECK_CLICKED, {
+          [TRACKING_METADATA.DECK_ID]: deckId,
+          [TRACKING_METADATA.DECK_NAME]: deck,
+          [TRACKING_METADATA.IS_DAILY_DECK]: date ? true : false,
+        });
+      }}
       className="bg-gray-700 border-gray-500 rounded-2xl p-4 flex gap-4 cursor-pointer h-full"
     >
       <div className="w-[90px] h-[90px] flex-shrink-0 relative">

--- a/app/constants/tracking.ts
+++ b/app/constants/tracking.ts
@@ -28,6 +28,7 @@ export const TRACKING_EVENTS = {
   HOME_STAT_CARD_DIALOG_CLOSED: "HomeStatCardDialogClosed",
   WELCOME_BACK_ANSWER_BUTTON_CLICKED: "WelcomeBackAnswerButtonClicked",
   WELCOME_BACK_REVEAL_BUTTON_CLICKED: "WelcomeBackRevealButtonClicked",
+  DECK_CLICKED: "DeckClicked",
 } as const;
 
 export const TRACKING_METADATA = {


### PR DESCRIPTION
- Description
This PR add `DeckClicked` mixpanel event to track the interaction of Decks from homepage
- What are the steps to test that this code is working?
Click a deck from Expiring Soon section and verify the event from mixpanel dashboard
- Screen shots or recordings for UI changes
<img width="1326" alt="Screenshot 2024-10-21 at 10 56 59 PM" src="https://github.com/user-attachments/assets/a0674782-2867-4a83-bbbb-0768571dde09">
