### PR TITLE
PROD-398 Add device ID for Identity management

### DIFF
--- a/app/api/mixpanel/route.test.ts
+++ b/app/api/mixpanel/route.test.ts
@@ -2,8 +2,19 @@ import { NextRequest } from 'next/server';
 import Mixpanel from 'mixpanel';
 import { POST } from './route';
 import { getCurrentUser } from "@/app/queries/user";
+import { cookies } from 'next/headers';
+import { v4 as uuidv4 } from 'uuid';
 
 // Mock dependencies
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+  })),
+}));
+jest.mock('uuid', () => ({
+  v4: jest.fn(),
+}));
 jest.mock('@/lib/kv');
 jest.mock('mixpanel', () => {
   return {
@@ -19,12 +30,23 @@ jest.mock('@/app/queries/user', () => ({
 describe('Mixpanel tracking route', () => {
   let mockRequest: NextRequest;
   let mockMixpanelTrack: jest.Mock;
+  let mockCookies: {
+    get: jest.Mock;
+    set: jest.Mock;
+  };
   
   beforeEach(() => {
     jest.resetAllMocks();
     mockMixpanelTrack = jest.fn();
     (Mixpanel.init as jest.Mock).mockReturnValue({ track: mockMixpanelTrack });
     (getCurrentUser as jest.Mock).mockResolvedValue(null);
+
+    mockCookies = {
+      get: jest.fn(),
+      set: jest.fn(),
+    };
+    (cookies as jest.Mock).mockReturnValue(mockCookies);
+    (uuidv4 as jest.Mock).mockReturnValue('mock-device-id');
 
     // Mock Request with utm params as property
     mockRequest = {


### PR DESCRIPTION
### Description
This PR implements server-side Identity Management to track events or UTM for pre-login and post-login users. It will allow us to track both kinds of users and connect the identities. Helpful in lead conversion and other metrics. `$device_id` will be a common attribute between pre-login and post-login.
### What are the steps to test that this code is working?
Open various pages with UTM parameters and interact with them. Then, log in and interact with the reveal feature. After that, check the Mixpanel dashboard to ensure those events are being tracked correctly.
### Screenshots or recordings for UI changes
Pre-login
![Screenshot 2024-10-22 at 4 48 37 PM](https://github.com/user-attachments/assets/8277a036-0f0e-4a8c-a7fb-1f04e1f95b52)
Post-login
![Screenshot 2024-10-22 at 4 48 27 PM](https://github.com/user-attachments/assets/b8e1c06f-db1e-4850-83e0-568c0d74296d)
