### PR TITLE
PROD-428 enabled navbar for logged-out users

### DIFF
--- a/app/stacks/layout.tsx
+++ b/app/stacks/layout.tsx
@@ -43,7 +43,7 @@ const StacksLayout = async ({ children }: PageLayoutProps) => {
         )}
         {children}
       </Main>
-      {!!user && <TabNavigation isAdmin={!!user?.isAdmin} />}
+      {<TabNavigation isAdmin={!!user?.isAdmin} />}
     </div>
   );
 };


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the Linear task: https://linear.app/gator/issue/PROD-428/show-navbar-for-logged-out-users
- What are the steps to test that this code is working?
- Go to the /stacks page. Navbar should appear even if you are logged out user. If you click on home, next step should be redirection to the /login page.
- Screen shots or recordings for UI changes
- 

https://github.com/user-attachments/assets/dc39158a-761f-4cd2-8909-898c22acad71

<img width="1296" alt="Screenshot 2024-10-31 at 22 48 33" src="https://github.com/user-attachments/assets/43512df7-6e6a-49ae-b832-96bcde3d0a04">

