### PR TITLE
PROD-450/allow-questions-to-be-revealed-with-only-3-answers 

### DIFF
--- a/app/actions/leaderboard.ts
+++ b/app/actions/leaderboard.ts
@@ -44,7 +44,7 @@ export const getPreviousUserRank = async (
     return;
 
   const currentUser = await getCurrentUser();
-  
+
   const dateRange = getDateRange(variant, true);
   const { endDate: expirationDate } = getDateRange(variant)!;
 

--- a/app/utils/question.ts
+++ b/app/utils/question.ts
@@ -202,12 +202,14 @@ export const getTotalNumberOfDeckQuestions = (
     };
   })[],
 ) => {
-  return deckQuestions.filter((dq) =>
-    dq.question.questionOptions.every((qo) => {
-      return (
-        qo.questionAnswers.length / dq.question.questionOptions.length >=
-        Number(process.env.MINIMAL_ANSWERS_PER_QUESTION)
-      );
-    }),
-  ).length;
+  return deckQuestions.filter((dq) => {
+    const numberOfAnswers = dq.question.questionOptions
+      .flatMap((qo) => qo.questionAnswers)
+      .filter(
+        (item, index, self) =>
+          index === self.findIndex((el) => el.userId === item.userId),
+      ).length;
+
+    return numberOfAnswers >= Number(process.env.MINIMAL_ANSWERS_PER_QUESTION);
+  }).length;
 };

--- a/app/utils/question.ts
+++ b/app/utils/question.ts
@@ -203,10 +203,12 @@ export const getTotalNumberOfDeckQuestions = (
   })[],
 ) => {
   return deckQuestions.filter((dq) =>
-    dq.question.questionOptions.every(
-      (qo) =>
+    dq.question.questionOptions.every((qo) => {
+      return (
         qo.questionAnswers.length >=
-        Number(process.env.MINIMAL_ANSWERS_PER_QUESTION),
-    ),
+        Number(process.env.MINIMAL_ANSWERS_PER_QUESTION) /
+          dq.question.questionOptions.length
+      );
+    }),
   ).length;
 };

--- a/app/utils/question.ts
+++ b/app/utils/question.ts
@@ -205,9 +205,8 @@ export const getTotalNumberOfDeckQuestions = (
   return deckQuestions.filter((dq) =>
     dq.question.questionOptions.every((qo) => {
       return (
-        qo.questionAnswers.length >=
-        Number(process.env.MINIMAL_ANSWERS_PER_QUESTION) /
-          dq.question.questionOptions.length
+        qo.questionAnswers.length / dq.question.questionOptions.length >=
+        Number(process.env.MINIMAL_ANSWERS_PER_QUESTION)
       );
     }),
   ).length;


### PR DESCRIPTION
@marvinmarnold We can update MINIMAL_ANSWERS_PER_QUESTION to 5. Also I needed to divide questionAnswers.length with questionOptions.length in getTotalNumberOfDeckQuestions function. Because if we have multi choice question, and that question has 4 answers by one user. It is actually only one answer, because we are storing answer for each option of a question in a db.  