### PR TITLE
PROD-402: add db constraint on fungibleAssetTransactionLog.

### DIFF
--- a/prisma/migrations/20241030104838_add_telegram_username/migration.sql
+++ b/prisma/migrations/20241030104838_add_telegram_username/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "User" ADD COLUMN     "telegramUsername" TEXT UNIQUE; 
+ALTER TABLE "User" ADD COLUMN "telegramUsername" TEXT UNIQUE; 

--- a/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
+++ b/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
@@ -6,7 +6,7 @@
 
 */
 -- CreateIndex
-CREATE UNIQUE INDEX "FungibleAssetTransactionLog_userId_questionId_key" ON "FungibleAssetTransactionLog"("userId", "questionId");
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_type_userId_questionId_key" ON "FungibleAssetTransactionLog"("type", "userId", "questionId");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" ON "FungibleAssetTransactionLog"("deckId", "userId");

--- a/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
+++ b/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
@@ -1,12 +1,12 @@
 /*
   Warnings:
 
-  - A unique constraint covering the columns `[userId,questionId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
-  - A unique constraint covering the columns `[deckId,userId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[type, userId,questionId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[type, deckId,userId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
 
 */
 -- CreateIndex
 CREATE UNIQUE INDEX "FungibleAssetTransactionLog_type_userId_questionId_key" ON "FungibleAssetTransactionLog"("type", "userId", "questionId");
 
 -- CreateIndex
-CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" ON "FungibleAssetTransactionLog"("deckId", "userId");
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" ON "FungibleAssetTransactionLog"("type", "deckId", "userId");

--- a/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
+++ b/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
@@ -41,5 +41,5 @@ CREATE UNIQUE INDEX "FungibleAssetTransactionLog_type_userId_questionId_key"
 ON "FungibleAssetTransactionLog"("type", "userId", "questionId");
 
 -- Create unique index for `type`, `deckId`, and `userId`
-CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" 
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_type_deckId_userId_key" 
 ON "FungibleAssetTransactionLog"("type", "deckId", "userId");

--- a/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
+++ b/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId,questionId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[deckId,userId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_userId_questionId_key" ON "FungibleAssetTransactionLog"("userId", "questionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" ON "FungibleAssetTransactionLog"("deckId", "userId");

--- a/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
+++ b/prisma/migrations/20241108065629_add_unique_deckid_userid/migration.sql
@@ -1,12 +1,45 @@
 /*
   Warnings:
 
-  - A unique constraint covering the columns `[type, userId,questionId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
-  - A unique constraint covering the columns `[type, deckId,userId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[type, userId, questionId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[type, deckId, userId]` on the table `FungibleAssetTransactionLog` will be added. If there are existing duplicate values, this will fail.
 
 */
--- CreateIndex
-CREATE UNIQUE INDEX "FungibleAssetTransactionLog_type_userId_questionId_key" ON "FungibleAssetTransactionLog"("type", "userId", "questionId");
 
--- CreateIndex
-CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" ON "FungibleAssetTransactionLog"("type", "deckId", "userId");
+-- Remove duplicates for `type`, `userId`, and `questionId`
+WITH CTE_KeepOldest AS (
+    SELECT 
+        MIN(ctid) AS oldest_ctid
+    FROM "FungibleAssetTransactionLog"
+    WHERE "questionId" IS NOT NULL
+    GROUP BY "type", "userId", "questionId"
+)
+DELETE FROM "FungibleAssetTransactionLog"
+WHERE "questionId" IS NOT NULL
+AND ctid NOT IN (
+    SELECT oldest_ctid
+    FROM CTE_KeepOldest
+);
+
+-- Remove duplicates for `type`, `deckId`, and `userId`
+WITH CTE_KeepOldest AS (
+    SELECT 
+        MIN(ctid) AS oldest_ctid
+    FROM "FungibleAssetTransactionLog"
+    WHERE "deckId" IS NOT NULL
+    GROUP BY "type", "deckId", "userId"
+)
+DELETE FROM "FungibleAssetTransactionLog"
+WHERE "deckId" IS NOT NULL
+AND ctid NOT IN (
+    SELECT oldest_ctid
+    FROM CTE_KeepOldest
+);
+
+-- Create unique index for `type`, `userId`, and `questionId`
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_type_userId_questionId_key" 
+ON "FungibleAssetTransactionLog"("type", "userId", "questionId");
+
+-- Create unique index for `type`, `deckId`, and `userId`
+CREATE UNIQUE INDEX "FungibleAssetTransactionLog_deckId_userId_key" 
+ON "FungibleAssetTransactionLog"("type", "deckId", "userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,10 @@ model FungibleAssetTransactionLog {
   questionId Int?
   deck       Deck?              @relation(fields: [deckId], references: [id])
   deckId     Int?
+
+  @@unique([userId, questionId])  // Enforce unique combination of userId and questionId
+  @@unique([deckId, userId])      // Enforce unique combination of deckId and userId
+
 }
 
 model FungibleAssetBalance {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -189,7 +189,7 @@ model FungibleAssetTransactionLog {
   deckId     Int?
 
   @@unique([type, userId, questionId])  // Enforce unique combination of userId and questionId
-  @@unique([deckId, userId])      // Enforce unique combination of deckId and userId
+  @@unique([type, deckId, userId])      // Enforce unique combination of deckId and userId
 
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -188,7 +188,7 @@ model FungibleAssetTransactionLog {
   deck       Deck?              @relation(fields: [deckId], references: [id])
   deckId     Int?
 
-  @@unique([userId, questionId])  // Enforce unique combination of userId and questionId
+  @@unique([type, userId, questionId])  // Enforce unique combination of userId and questionId
   @@unique([deckId, userId])      // Enforce unique combination of deckId and userId
 
 }


### PR DESCRIPTION
- Description
Previously it was possible to invoke the answer question endpoint and get as many point as user want to prevent that now we have db constraint to prevent duplicate entry for the same userId and questionId and for deckId and questionId
- What are the steps to test that this code is working?
No duplicates answer point for the same deck or question id.
- Screen shots or recordings for UI changes
N/A
