### PR TITLE
PROD-448 Debounce Second Order Selection Tracking

### DIFF
--- a/app/actions/leaderboard.ts
+++ b/app/actions/leaderboard.ts
@@ -44,7 +44,7 @@ export const getPreviousUserRank = async (
     return;
 
   const currentUser = await getCurrentUser();
-  
+
   const dateRange = getDateRange(variant, true);
   const { endDate: expirationDate } = getDateRange(variant)!;
 

--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -219,6 +219,13 @@ export function Deck({
       }
 
       if (currentQuestionStep === QuestionStep.PickPercentage) {
+        trackQuestionAnswer(
+          question,
+          "SECOND_ORDER",
+          deckId,
+          deckVariant,
+          optionPercentage,
+        );
         setDeckResponse((prev) => {
           const newResponses = [...prev];
           const response = newResponses.pop();

--- a/app/components/Question/Question.tsx
+++ b/app/components/Question/Question.tsx
@@ -130,6 +130,13 @@ export function Question({ question, returnUrl }: QuestionProps) {
       }
 
       if (currentQuestionStep === QuestionStep.PickPercentage) {
+        trackQuestionAnswer(
+          question,
+          "SECOND_ORDER",
+          undefined,
+          undefined,
+          optionPercentage,
+        );
         handleSaveQuestion({
           ...answerState,
           percentageGiven: optionPercentage,

--- a/app/components/QuestionAction/QuestionAction.tsx
+++ b/app/components/QuestionAction/QuestionAction.tsx
@@ -2,8 +2,7 @@
 
 import { trackQuestionAnswer } from "@/app/utils/tracking";
 import { QuestionType } from "@prisma/client";
-import debounce from "lodash/debounce";
-import { Dispatch, SetStateAction, useCallback, useState } from "react";
+import { Dispatch, SetStateAction, useState } from "react";
 
 import { Button } from "../Button/Button";
 import { Question } from "../Deck/Deck";
@@ -52,28 +51,6 @@ export function QuestionAction({
       setIsSliderTouched(true);
     }
   };
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedTrackAnswer = useCallback(
-    debounce(
-      (
-        question: Question,
-        deckId?: number,
-        deckVariant?: string,
-        value?: number,
-      ) => {
-        trackQuestionAnswer(
-          question,
-          "SECOND_ORDER",
-          deckId,
-          deckVariant,
-          value,
-        );
-      },
-      500,
-    ),
-    [],
-  );
 
   if (type === "BinaryQuestion" && step === QuestionStep.AnswerQuestion) {
     return (
@@ -124,8 +101,6 @@ export function QuestionAction({
                 if (setPercentage) {
                   setPercentage(value);
                 }
-                if (question)
-                  debouncedTrackAnswer(question, deckId, deckVariant, value);
               }}
               labelLeft="No one"
               labelRight="Everyone"

--- a/app/components/QuestionAction/QuestionAction.tsx
+++ b/app/components/QuestionAction/QuestionAction.tsx
@@ -2,7 +2,8 @@
 
 import { trackQuestionAnswer } from "@/app/utils/tracking";
 import { QuestionType } from "@prisma/client";
-import { Dispatch, SetStateAction, useState } from "react";
+import debounce from "lodash/debounce";
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
 
 import { Button } from "../Button/Button";
 import { Question } from "../Deck/Deck";
@@ -51,6 +52,28 @@ export function QuestionAction({
       setIsSliderTouched(true);
     }
   };
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const debouncedTrackAnswer = useCallback(
+    debounce(
+      (
+        question: Question,
+        deckId?: number,
+        deckVariant?: string,
+        value?: number,
+      ) => {
+        trackQuestionAnswer(
+          question,
+          "SECOND_ORDER",
+          deckId,
+          deckVariant,
+          value,
+        );
+      },
+      500,
+    ),
+    [],
+  );
 
   if (type === "BinaryQuestion" && step === QuestionStep.AnswerQuestion) {
     return (
@@ -102,13 +125,7 @@ export function QuestionAction({
                   setPercentage(value);
                 }
                 if (question)
-                  trackQuestionAnswer(
-                    question,
-                    "SECOND_ORDER",
-                    deckId,
-                    deckVariant,
-                    value,
-                  );
+                  debouncedTrackAnswer(question, deckId, deckVariant, value);
               }}
               labelLeft="No one"
               labelRight="Everyone"


### PR DESCRIPTION
- Description
It adds debounce to avoid too many requests at same time if user drags the slider continuously. It will delay the tracking call by 0.5 secs after percentage value changes.

- What are the steps to test that this code is working?
Answer second order and drag slider continuously. Verify the events recorded in mixpanel dashboard. It shouldn't hit too many requests at same time.

- Screen shots or recordings for UI changes
