### PR TITLE
fix: show formatted date after hydration in question card

### DIFF
--- a/app/components/QuestionCard/QuestionCard.tsx
+++ b/app/components/QuestionCard/QuestionCard.tsx
@@ -54,7 +54,6 @@ export function QuestionCard({
   const handleDueAtFormatted = useCallback(() => {
     if (!dueAt || hasDurationRanOut) return;
 
-    setDueAtFormatted(getDueAtString(dueAt));
     if (dayjs(dueAt).diff(new Date(), "seconds") <= 0) {
       if (onDurationRanOut) {
         onDurationRanOut();
@@ -62,6 +61,12 @@ export function QuestionCard({
       }
     }
   }, [dueAt, onDurationRanOut, hasDurationRanOut]);
+
+  useEffect(() => {
+    if (dueAt) {
+      setDueAtFormatted(getDueAtString(dueAt));
+    }
+  }, [dueAt]);
 
   useEffect(() => {
     // Reset the hasDurationRanOut state when the question changes


### PR DESCRIPTION
- Description
Resolved the hydration error from question card date mismatch in server and client by showing the date after client loads. 
- What are the steps to test that this code is working?
It should not throw hydration error in sentry or console in the PWA from question answer page
- Screen shots or recordings for UI changes
N/A
