### PR TITLE
fix: env vars for tg tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,3 +27,5 @@ jobs:
           KV_REST_API_URL: ${{ secrets.KV_REST_API_URL_DEMO }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN_DEMO }}
           MIX_PANEL_TOKEN: ${{ secrets.MIX_PANEL_TOKEN }}
+          BOT_API_KEY: 'foo!bar'
+          BOT_TOKEN: 'bar!foo'


### PR DESCRIPTION
- necessary env vars not available in tg tests