### PR TITLE
PROD-469: Resolve hydration error

### DIFF
--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -232,7 +232,10 @@ export function Deck({
           if (response) {
             response.percentageGiven = optionPercentage;
             response.percentageGivenForAnswerId =
-              question.questionOptions[random]?.id;
+              random !== undefined
+                ? question.questionOptions[random]?.id
+                : undefined;
+
             response.timeToAnswerInMiliseconds = getTimePassedSinceStart();
             newResponses.push(response);
           }
@@ -261,6 +264,7 @@ export function Deck({
       handleNextIndex,
       currentOptionSelected,
       optionPercentage,
+      random,
     ],
   );
 
@@ -316,9 +320,11 @@ export function Deck({
 
   // get random option for 2nd order question.
   const randomQuestionMarker =
-    question?.type === QuestionType.MultiChoice
-      ? getAlphaIdentifier(random)
-      : question.questionOptions[random].option;
+    random === undefined
+      ? undefined
+      : question?.type === QuestionType.MultiChoice
+        ? getAlphaIdentifier(random)
+        : question.questionOptions[random].option;
 
   return (
     <div className="flex flex-col justify-start h-full pb-4 w-full">
@@ -343,7 +349,11 @@ export function Deck({
               type={question.type}
               step={currentQuestionStep}
               questionOptions={question.questionOptions}
-              randomOptionId={question.questionOptions[random]?.id}
+              randomOptionId={
+                random !== undefined
+                  ? question.questionOptions[random]?.id
+                  : undefined
+              }
               percentage={optionPercentage}
               question={question}
             />

--- a/app/hooks/useRandom.ts
+++ b/app/hooks/useRandom.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { getRandomInteger } from "../utils/randomUtils";
 
@@ -8,7 +8,12 @@ type RandomProps = {
 };
 
 export function useRandom({ min, max }: RandomProps) {
-  const [random, setRandom] = useState(getRandomInteger(min, max));
+  const [random, setRandom] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    setRandom(getRandomInteger(min, max));
+  }, [min, max]);
+
   const generateRandom = useCallback(
     ({ min, max }: RandomProps) => {
       setRandom(getRandomInteger(min, max));


### PR DESCRIPTION
Resolves a hydration error due to non-deterministic call outside of a hook.

The original error can be reproduced by refreshing the answer question page a few times (occurs on a multi-choice question).