### PR TITLE
fix: Add sentry capture in share claim all drawer

### DIFF
--- a/app/components/ClaimShareDrawer/ClaimShareDrawer.tsx
+++ b/app/components/ClaimShareDrawer/ClaimShareDrawer.tsx
@@ -50,9 +50,10 @@ const ClaimShareDrawer = ({
       try {
         const linkPreview = await getLinkPreview(claimUrl);
         setOgImageUrl((linkPreview as { images: string[] }).images[0]);
-      } catch {
+      } catch (error) {
         const shareClaimAllError = new ShareClaimAllError(
           "Failed to fetch link preview",
+          { cause: error },
         );
         Sentry.captureException(shareClaimAllError);
       }

--- a/app/components/ClaimShareDrawer/ClaimShareDrawer.tsx
+++ b/app/components/ClaimShareDrawer/ClaimShareDrawer.tsx
@@ -1,9 +1,11 @@
 import { TRACKING_EVENTS } from "@/app/constants/tracking";
 import { useToast } from "@/app/providers/ToastProvider";
 import { copyTextToClipboard } from "@/app/utils/clipboard";
+import { ShareClaimAllError } from "@/lib/error";
 import trackEvent from "@/lib/trackEvent";
 import { getClaimAllShareUrl } from "@/lib/urls";
 import { DialogTitle } from "@radix-ui/react-dialog";
+import * as Sentry from "@sentry/nextjs";
 import { getLinkPreview } from "link-preview-js";
 import Image from "next/image";
 import { useEffect, useState } from "react";
@@ -49,7 +51,10 @@ const ClaimShareDrawer = ({
         const linkPreview = await getLinkPreview(claimUrl);
         setOgImageUrl((linkPreview as { images: string[] }).images[0]);
       } catch {
-        console.log("Failed to fetch share claim all preview");
+        const shareClaimAllError = new ShareClaimAllError(
+          "Failed to fetch link preview",
+        );
+        Sentry.captureException(shareClaimAllError);
       }
     };
 

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -70,3 +70,10 @@ export class CreateMysteryBoxError extends Error {
     this.name = "CreateMysteryBoxError";
   }
 }
+
+export class ShareClaimAllError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ShareClaimAllError";
+  }
+}


### PR DESCRIPTION
- Description
Sometimes share claim all drawer can't fetch the preview link and recently we moved it into try-catch. PR add patch to record that error in Sentry

- What are the steps to test that this code is working?
Verify from Sentry Dashboard after claim all

- Screen shots or recordings for UI changes
NA - Refactor