### PR TITLE
PROD-628: Fix claim action and sentry sanity check

### DIFF
--- a/app/actions/chompResult.ts
+++ b/app/actions/chompResult.ts
@@ -186,6 +186,7 @@ export async function revealQuestions(
     );
     release();
     Sentry.captureException(revealError);
+    await Sentry.flush(SENTRY_FLUSH_WAIT);
     return null;
   }
 
@@ -480,6 +481,7 @@ async function hasBonkBurnedCorrectly(
       },
       extra: { burnInstruction: burnInstruction },
     });
+    await Sentry.flush(SENTRY_FLUSH_WAIT);
     return false;
   }
 

--- a/app/actions/claim.ts
+++ b/app/actions/claim.ts
@@ -31,6 +31,7 @@ export async function getClaimableQuestionIds(): Promise<number[]> {
       userId: payload.sub,
       result: "Revealed",
       questionId: { not: null },
+      sendTransactionSignature: null,
       rewardTokenAmount: {
         gt: 0,
       },
@@ -130,6 +131,7 @@ export async function claimQuestions(questionIds: number[]) {
         questionId: {
           in: questionIds,
         },
+        sendTransactionSignature: null,
         result: ResultType.Revealed,
         OR: [
           {

--- a/app/actions/history.ts
+++ b/app/actions/history.ts
@@ -54,6 +54,7 @@ export async function getTotalClaimableRewards() {
       userId: payload.sub,
       result: "Revealed",
       questionId: { not: null },
+      sendTransactionSignature: null,
       rewardTokenAmount: {
         gt: 0,
       },
@@ -96,6 +97,7 @@ export async function getDeckTotalClaimableRewards(deckId: number) {
       userId: payload.sub,
       result: "Revealed",
       questionId: { not: null },
+      sendTransactionSignature: null,
       rewardTokenAmount: {
         gt: 0,
       },

--- a/app/components/ClaimButton/ClaimButton.tsx
+++ b/app/components/ClaimButton/ClaimButton.tsx
@@ -13,7 +13,7 @@ import { useConfetti } from "@/app/providers/ConfettiProvider";
 import { useToast } from "@/app/providers/ToastProvider";
 import { numberToCurrencyFormatter } from "@/app/utils/currency";
 import { CONNECTION } from "@/app/utils/solana";
-import { RevealConfirmationError } from "@/lib/error";
+import { ClaimError } from "@/lib/error";
 import trackEvent from "@/lib/trackEvent";
 import * as Sentry from "@sentry/nextjs";
 import { useQueryClient } from "@tanstack/react-query";
@@ -112,11 +112,11 @@ const ClaimButton = ({
           setIsClaiming(false);
         });
     } catch (e) {
-      const revealConfirmationError = new RevealConfirmationError(
-        `Trouble confirming reveal hash while claiming for user id: ${userId} and questions ids: ${questionIds}`,
+      const claimError = new ClaimError(
+        `Trouble claiming for user id: ${userId} and questions ids: ${questionIds}`,
         { cause: e },
       );
-      Sentry.captureException(revealConfirmationError, {
+      Sentry.captureException(claimError, {
         extra: {
           questionIds,
           chompResults: resultIds,

--- a/app/queries/mysteryBox.ts
+++ b/app/queries/mysteryBox.ts
@@ -139,13 +139,12 @@ async function rewardTutorialMysteryBox(
     });
     return res.id;
   } catch (e) {
-    console.log(e);
-
     const createMysteryBoxError = new CreateMysteryBoxError(
       `Trouble creating tutorail completion mystery box for User id: ${userId}`,
       { cause: e },
     );
     Sentry.captureException(createMysteryBoxError);
+    await Sentry.flush(SENTRY_FLUSH_WAIT);
     return null;
   }
 }


### PR DESCRIPTION
- Description
Stops double claiming in any case with valid conditions on query and fix the claim error capture issue with flush

- What are the steps to test that this code is working?
NA

- Screen shots or recordings for UI changes
NA