### PR TITLE
fix(PROD-668): set compute units unless a token account must be created 

### DIFF
--- a/app/utils/claim.ts
+++ b/app/utils/claim.ts
@@ -133,6 +133,20 @@ export const sendBonk = async (
   // update the instructions with compute budget instruction.
   instructions.unshift(computeBudgetIx);
 
+  if (!!receiverAccountInfo) {
+    // based on historical transaction cost
+    // eg https://solscan.io/tx/5KeHyDz2zcVJkHB3E83G1PyGhPkT8nkqPb1QW6Nz2iAkaZrLRYgBGaAvZTp8zLCU7ncB1VNrB2L1YmSg5zNBWR5q
+    const computeUnitFix = 4794;
+
+    // Buffer to make sure the transaction doesn't fail because of insufficient compute units
+    const computeUnitsIx = ComputeBudgetProgram.setComputeUnitLimit({
+      units: Math.round(computeUnitFix * 1.1),
+    });
+
+    // update the instructions with compute unit instruction (unshift will move compute unit to the start and it is recommended in docs as well.)
+    instructions.unshift(computeUnitsIx);
+  }
+
   blockhashResponse = await CONNECTION.getLatestBlockhash("finalized");
 
   const v0updatedMessage = new TransactionMessage({


### PR DESCRIPTION
- Reverts change in: https://github.com/gator-labs/chomp/pull/809/files
- May require follow up work to set compute limit even when there is no token account