### PR TITLE
fix: refactor sentry tracking for failed reveals

### DIFF
--- a/app/actions/chompResult.ts
+++ b/app/actions/chompResult.ts
@@ -188,7 +188,12 @@ export async function revealQuestions(
       `User with id: ${payload?.sub} is missing transaction hash or nft for revealing question ids: ${questionIds}`,
     );
     release();
-    Sentry.captureException(revealError);
+    Sentry.captureException(revealError, {
+      extra: {
+        questionIds,
+        burnTx,
+      },
+    });
     await Sentry.flush(SENTRY_FLUSH_WAIT);
     return null;
   }
@@ -294,6 +299,7 @@ export async function revealQuestions(
       extra: {
         existingFatl: existingFatl,
         newFatl: revealPoints,
+        questionIds: questionIds,
       },
     });
   }

--- a/app/hooks/useReveal.ts
+++ b/app/hooks/useReveal.ts
@@ -342,6 +342,9 @@ export function useReveal({
             tags: {
               category: "burn-error",
             },
+            extra: {
+              questionIds,
+            },
           });
           release();
           resetReveal();
@@ -424,7 +427,14 @@ export function useReveal({
         `User with id: ${payload?.sub} (wallet: ${address}) is having trouble revealing questions with question ids: ${questionIds}`,
         { cause: error },
       );
-      Sentry.captureException(revealError);
+      Sentry.captureException(revealError, {
+        tags: {
+          category: "reveal-error",
+        },
+        extra: {
+          questionIds,
+        },
+      });
       release();
     } finally {
       resetReveal();


### PR DESCRIPTION
Added questionIds in extra as it is an important parameter while debugging failed reveals. 