### PR TITLE
PROD-595 updated calc and text

### DIFF
--- a/app/components/DashboardUserStats/DashboardUserStats.tsx
+++ b/app/components/DashboardUserStats/DashboardUserStats.tsx
@@ -31,10 +31,10 @@ export async function DashboardUserStats() {
       />
       <StatsBox
         title={totalClaimedAmount.toLocaleString("en-US")}
-        description="BONK Claimed"
+        description="BONK Won"
         icon={<InfoIcon width={25} height={25} />}
         drawerProps={{
-          title: "BONK Claimed",
+          title: "BONK Won",
           description:
             "Knowledge pays off. Earn BONK for providing the best answers. Keep stacking! ",
           type: HOME_STAT_CARD_TYPE.BONK_CLAIMED as keyof typeof HOME_STAT_CARD_TYPE,


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
  The issue here was that user stats was displaying the number of claimed rewards from questions. This change also takes into account the claimed rewards from Mystery boxes. I've not written any additional queries. I've used methods for rewards calculations that was already implemented in Mystery box case. Description of the task does not give you exact context so check pinned conversation in the task.
- Link to the Liner task https://linear.app/gator/issue/PROD-595/change-mystery-box-text-to-always-say-won-and-refer-to-all-bonk-won-to
- What are the steps to test that this code is working?
- Screen shots or recordings for UI changes
Before updates:

<img width="536" alt="Screenshot 2025-01-08 at 15 10 15" src="https://github.com/user-attachments/assets/567647f1-1353-4b15-95f9-cdf7c1c4f739" />

After updates:

https://github.com/user-attachments/assets/068a2324-4a96-4361-a84a-c9ef51c9a9bf




