### PR TITLE
Fix: restore previous behaviour on burn failure.

### DIFF
--- a/app/hooks/useReveal.ts
+++ b/app/hooks/useReveal.ts
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useState } from "react";
 import { DynamicRevealError, RevealError } from "../../lib/error";
 import {
   createChompResultsAndSubmitSignedTx,
+  deleteQuestionChompResults,
   getUsersPendingChompResult,
 } from "../actions/chompResult";
 import { getJwtPayload } from "../actions/jwt";
@@ -406,6 +407,10 @@ export function useReveal({
         setRevealNft(undefined);
       }
     } catch (error) {
+      if (pendingChompResultIds.length > 0) {
+        await deleteQuestionChompResults(pendingChompResultIds);
+      }
+
       await trackEvent(TRACKING_EVENTS.REVEAL_FAILED, {
         [TRACKING_METADATA.REVEAL_TYPE]: reveal?.isRevealAll
           ? REVEAL_TYPE.ALL


### PR DESCRIPTION
The previous behaviour on failure during signing the burn transaction was to delete the chomp results that had been created. These hanging results seem to result in issues when coming back to reveal. I'm restoring the previous behaviour temporarily but want to return to this issue once I've accounted for all code paths: I think ideally we should not be deleting results.