### PR TITLE
fix: limit reveal cards to 100

### DIFF
--- a/app/queries/home.ts
+++ b/app/queries/home.ts
@@ -274,6 +274,7 @@ async function queryQuestionsForReadyToReveal(
   AND
   qa.selected = true AND qa."userId" = ${userId}
   ORDER BY  q."createdAt" DESC
+  LIMIT 100
   `;
 
   return revealQuestions;


### PR DESCRIPTION
- Description
There were a reload issue in reveal cards in mobiles when user have ~500 or more reveal cards. 

