### PR TITLE
PROD-664 added check for wallet address in rank items for all time leaderboard

### DIFF
--- a/__tests__/utils/getUsernameForLeaderboard.test.ts
+++ b/__tests__/utils/getUsernameForLeaderboard.test.ts
@@ -1,0 +1,22 @@
+import { getUsername } from "@/app/utils/getUsernameForLeaderboard";
+
+jest.mock("@/app/utils/wallet", () => ({
+  formatAddress: jest.fn((address) => `formatted_${address}`),
+}));
+
+describe("getUserName", () => {
+  it("should return the username if it exists", () => {
+    const user = { username: "testuser", wallets: [] };
+    expect(getUsername(user)).toBe("@testuser");
+  });
+
+  it("should return the formatted address if username does not exist but address exists", () => {
+    const user = { username: undefined, wallets: [{ address: "0x123" }] };
+    expect(getUsername(user)).toBe("formatted_0x123");
+  });
+
+  it("should return 'mocked user' if neither username nor address exists", () => {
+    const user = { username: undefined, wallets: [] };
+    expect(getUsername(user)).toBe("mocked user");
+  });
+});

--- a/app/components/LeaderboardRanking/LeaderboardRanking.tsx
+++ b/app/components/LeaderboardRanking/LeaderboardRanking.tsx
@@ -30,8 +30,8 @@ const LeaderboardRanking = ({ label, loggedUserId, ranking }: Props) => {
           {ranking.map((rankItem) => {
             const name = rankItem.user.username
               ? `@${rankItem.user.username}`
-              : rankItem.user.wallets[0].address
-                ? formatAddress(rankItem.user.wallets[0].address)
+              : rankItem.user.wallets[0]?.address
+                ? formatAddress(rankItem.user.wallets[0]?.address)
                 : "mocked user";
             return (
               <RankingCard

--- a/app/components/LeaderboardRanking/LeaderboardRanking.tsx
+++ b/app/components/LeaderboardRanking/LeaderboardRanking.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { formatAddress } from "@/app/utils/wallet";
+import { getUsername } from "@/app/utils/getUsernameForLeaderboard";
 import AvatarPlaceholder from "@/public/images/avatar_placeholder.png";
 import { User, Wallet } from "@prisma/client";
 
@@ -28,11 +28,7 @@ const LeaderboardRanking = ({ label, loggedUserId, ranking }: Props) => {
       {!!ranking.length ? (
         <ul className="flex flex-col gap-2 overflow-y-auto">
           {ranking.map((rankItem) => {
-            const name = rankItem.user.username
-              ? `@${rankItem.user.username}`
-              : rankItem.user.wallets[0]?.address
-                ? formatAddress(rankItem.user.wallets[0]?.address)
-                : "mocked user";
+            const name = getUsername(rankItem.user);
             return (
               <RankingCard
                 key={rankItem.user.id}

--- a/app/utils/getUsernameForLeaderboard.ts
+++ b/app/utils/getUsernameForLeaderboard.ts
@@ -1,0 +1,14 @@
+import { formatAddress } from "./wallet";
+
+export const getUsername = (user: {
+  username?: string | null;
+  wallets: { address?: string }[];
+}): string => {
+  if (user.username) {
+    return `@${user.username}`;
+  } else if (user.wallets.length > 0 && user.wallets[0]?.address) {
+    return formatAddress(user.wallets[0].address);
+  } else {
+    return "mocked user";
+  }
+};


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue
Link to the Linear task 
https://linear.app/gator/issue/PROD-664/400-error-on-all-time-leaderboard-on-stagingchompgames
- Description
I've managed to reproduce it on staging via wallet address that Yihwan mentioned in the task, unfortunately (luckily) not on PROD. I think something is related to accounts (wallets) so I've added conditional checks that will prevent breaking the page.
- What are the steps to test that this code is working?
- Screen shots or recordings for UI changes
- After the fix
<img width="1135" alt="Screenshot 2025-01-13 at 16 45 35" src="https://github.com/user-attachments/assets/b413b5e2-6dcf-4ec2-9a2d-dda6c8eb3734" />