### PR TITLE
PROD-613: Ignore TypeError in Sentry

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -9,4 +9,5 @@ export const ignoreErrors = [
   "Cannot destructure property 'address' of '(intermediate value)' as it is undefined.",
   "t.json is not a function. (In 't.json()', 't.json' is undefined)",
   "User is having trouble logging in: [object Object]",
+  "Cannot assign to read only property 'request' of object '#<c>'",
 ];


### PR DESCRIPTION
- Description
It ignores TypeError: Cannot assign to read only property 'request' of object '#<c>' in Sentry as it relates to extension.

- What are the steps to test that this code is working?
NA
- Screen shots or recordings for UI changes
NA