### PR TITLE
feat: fetch link preview after drawer open

### DIFF
--- a/app/components/ClaimShareDrawer/ClaimShareDrawer.tsx
+++ b/app/components/ClaimShareDrawer/ClaimShareDrawer.tsx
@@ -42,8 +42,11 @@ const ClaimShareDrawer = ({
   useEffect(() => {
     const fetchLinkPreview = async () => {
       try {
-        const linkPreview = await getLinkPreview(copyUrl);
-        setOgImageUrl((linkPreview as { images: string[] }).images[0]);
+        // only fetch the link preview if the drawer is open
+        if (isOpen) {
+          const linkPreview = await getLinkPreview(copyUrl);
+          setOgImageUrl((linkPreview as { images: string[] }).images[0]);
+        }
       } catch (error) {
         const shareClaimAllError = new ShareClaimAllError(
           "Failed to fetch link preview",


### PR DESCRIPTION
Linear Ticket: https://linear.app/gator/issue/PROD-605/shareclaimallerror-failed-to-fetch-link-preview

- Description
ClaimShareDrawer useEffect was running after the history page renders and fetches the preview link even if there isn't any tx hash.
- What are the steps to test that this code is working?
No shareclaimerror on history page render.
- Screen shots or recordings for UI changes
N/A
