### PR TITLE
PROD-697: Fix flaky Chompmas tests

### DIFF
--- a/__tests__/actions/chompmas-mystery-box.test.ts
+++ b/__tests__/actions/chompmas-mystery-box.test.ts
@@ -161,6 +161,10 @@ describe("Chompmas mystery boxes", () => {
   });
 
   it("Should refuse a chompmas box for user without a streak", async () => {
+    await prisma.mysteryBoxAllowlist.create({
+      data: { address: user2.wallet },
+    });
+
     const boxId = await getChompmasMysteryBox(
       user2.id,
       Number(process.env.NEXT_PUBLIC_CHOMPMAS_MIN_STREAK!) - 1,

--- a/__tests__/actions/chompmas-mystery-box.test.ts
+++ b/__tests__/actions/chompmas-mystery-box.test.ts
@@ -67,17 +67,17 @@ describe("Chompmas mystery boxes", () => {
     user0 = {
       id: users[0].id,
       username: users[0].username,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
     user1 = {
       id: users[1].id,
       username: users[1].username,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
     user2 = {
       id: users[2].id,
       username: users[2].username,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
 
     await prisma.user.createMany({

--- a/__tests__/actions/credits/updateTxStatusConfirm.test.ts
+++ b/__tests__/actions/credits/updateTxStatusConfirm.test.ts
@@ -19,7 +19,7 @@ describe("updateTxStatusToConfirmed", () => {
     const users = await generateUsers(1);
     user = {
       id: users[0].id,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
 
     await prisma.user.create({
@@ -43,7 +43,7 @@ describe("updateTxStatusToConfirmed", () => {
         wallet: user.wallet,
         feeSolAmount: "0",
         recipientAddress: faker.string.hexadecimal({
-          length: { min: 32, max: 44 },
+          length: { min: 32, max: 42 },
         }),
         type: EChainTxType.CreditPurchase,
       },

--- a/__tests__/actions/credits/updateTxStatusFinalized.test.ts
+++ b/__tests__/actions/credits/updateTxStatusFinalized.test.ts
@@ -24,7 +24,7 @@ describe("updateTxStatusToFinalized", () => {
     const users = await generateUsers(1);
     user = {
       id: users[0].id,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
 
     await prisma.user.create({
@@ -48,7 +48,7 @@ describe("updateTxStatusToFinalized", () => {
         wallet: user.wallet,
         feeSolAmount: "0",
         recipientAddress: faker.string.hexadecimal({
-          length: { min: 32, max: 44 },
+          length: { min: 32, max: 42 },
         }),
         type: EChainTxType.CreditPurchase,
       },

--- a/__tests__/actions/mystery-box.test.ts
+++ b/__tests__/actions/mystery-box.test.ts
@@ -142,12 +142,12 @@ describe("Create mystery box", () => {
     user0 = {
       id: users[0].id,
       username: users[0].username,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
     user1 = {
       id: users[1].id,
       username: users[1].username,
-      wallet: faker.string.hexadecimal({ length: { min: 32, max: 44 } }),
+      wallet: faker.string.hexadecimal({ length: { min: 32, max: 42 } }),
     };
 
     await prisma.user.createMany({


### PR DESCRIPTION
Fix tests: don't generate wallet addresses >= 44 chars.

Faker doesn't include the 0x prefix in its length limits.