### PR TITLE
Prod 682 author image fix

### DIFF
--- a/app/actions/deck/deck.ts
+++ b/app/actions/deck/deck.ts
@@ -177,7 +177,16 @@ export async function createDeck(data: z.infer<typeof deckSchema>) {
   const validatedFields = deckSchema.safeParse(data);
 
   if (!validatedFields.success) {
-    return { errorMessage: "Validaiton failed" };
+    return { errorMessage: "Validation failed" };
+  }
+
+  if (validatedFields.data.authorImageUrl) {
+    const isBucketImageValid = await validateBucketImage(
+      validatedFields.data.authorImageUrl.split("/").pop()!,
+      validatedFields.data.authorImageUrl,
+    );
+
+    if (!isBucketImageValid) throw new Error("Invalid image");
   }
 
   const images = data.questions
@@ -209,6 +218,8 @@ export async function createDeck(data: z.infer<typeof deckSchema>) {
         description: validatedFields.data.description,
         footer: validatedFields.data.footer,
         heading: validatedFields.data.heading,
+        author: validatedFields.data.author,
+        authorImageUrl: validatedFields.data.authorImageUrl,
       },
     });
 
@@ -287,6 +298,15 @@ export async function editDeck(data: z.infer<typeof deckSchema>) {
     const isBucketImageValid = await validateBucketImage(
       validatedFields.data.imageUrl.split("/").pop()!,
       validatedFields.data.imageUrl,
+    );
+
+    if (!isBucketImageValid) throw new Error("Invalid image");
+  }
+
+  if (validatedFields.data.authorImageUrl) {
+    const isBucketImageValid = await validateBucketImage(
+      validatedFields.data.authorImageUrl.split("/").pop()!,
+      validatedFields.data.authorImageUrl,
     );
 
     if (!isBucketImageValid) throw new Error("Invalid image");
@@ -401,6 +421,8 @@ export async function editDeck(data: z.infer<typeof deckSchema>) {
           footer: validatedFields.data.footer,
           description: validatedFields.data.description,
           heading: validatedFields.data.heading,
+          author: validatedFields.data.author,
+          authorImageUrl: validatedFields.data.authorImageUrl,
         },
       });
 

--- a/app/actions/jwt.ts
+++ b/app/actions/jwt.ts
@@ -6,14 +6,13 @@ import {
   VerifiedWallet,
   decodeJwtPayload,
 } from "@/lib/auth";
+import { checkThreatLevel, getTokenFromCookie } from "@/lib/jwt";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 import prisma from "../services/prisma";
 import { getRandomAvatarPath } from "../utils/avatar";
 import { resetAccountData } from "./demo";
-
-import { checkThreatLevel, getTokenFromCookie } from '@/lib/jwt';
 
 export const getJwtPayload = async () => {
   const token = getTokenFromCookie();

--- a/app/application/answer/page.tsx
+++ b/app/application/answer/page.tsx
@@ -61,6 +61,8 @@ export default async function Page() {
             description: deck.deckInfo.description,
             imageUrl: deck.deckInfo.imageUrl,
             totalNumberOfQuestions: deck.questions.length,
+            author: deck.deckInfo.author,
+            authorImageUrl: deck.deckInfo.authorImageUrl,
           }}
           numberOfUserAnswers={deck.numberOfUserAnswers!}
           totalCredits={totalCredits}

--- a/app/application/decks/[id]/page.tsx
+++ b/app/application/decks/[id]/page.tsx
@@ -30,6 +30,7 @@ export default async function Page({ params: { id } }: PageProps) {
   const totalCredits = await getUserTotalCreditAmount();
   let blurData;
   const imgUrl = deck?.deckInfo?.imageUrl || stackData?.image;
+
   if (imgUrl) {
     blurData = await getBlurData(imgUrl);
   }

--- a/app/components/AnswerResult/AnswerResult.tsx
+++ b/app/components/AnswerResult/AnswerResult.tsx
@@ -71,7 +71,7 @@ export function AnswerResult({
           <Avatar
             src={avatarSrc}
             size="extrasmall"
-            className="absolute top-1 "
+            className="absolute top-1 border-white"
             style={{ left: avatarLeft }}
           />
         )}

--- a/app/components/Avatar/Avatar.tsx
+++ b/app/components/Avatar/Avatar.tsx
@@ -43,8 +43,8 @@ export function Avatar({ src, size, className, style }: AvatarProps) {
       width={resolveDimensions()}
       height={resolveDimensions()}
       className={classNames(
-        "rounded-full border-2 border-white object-cover object-center",
         className,
+        "rounded-full border-2 object-cover object-center",
       )}
       sizes="(max-width: 600px) 40px, (min-width: 601px) 64px, (min-width: 1000px) 80px"
       style={{

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -70,9 +70,17 @@ export default function DeckForm({
     deck ? deck.date : undefined,
   );
 
-  const file = watch("file")?.[0];
-  const deckImage = watch("imageUrl");
+  const file = watch("file")?.[0]; // The file for deck image
+  const authorImageFile = watch("authorImageFile")?.[0]; // The file for the author image
+
+  const deckImage = watch("imageUrl"); // The URL for the deck image
+  const authorImage = watch("authorImageUrl"); // The URL for the author image
+
+  // Generate preview URLs for both the deck image and the author image
   const deckPreviewUrl = !!file ? URL.createObjectURL(file!) : deckImage;
+  const authorImagePreviewUrl = !!authorImageFile
+    ? URL.createObjectURL(authorImageFile!)
+    : authorImage;
 
   const onSubmit = handleSubmit(async (data) => {
     const questions = await Promise.all(
@@ -92,6 +100,11 @@ export default function DeckForm({
     );
 
     let imageUrl = deckPreviewUrl || "";
+    let authorImageUrl = authorImagePreviewUrl || "";
+
+    if (data.authorImageFile?.[0]) {
+      authorImageUrl = await uploadImageToS3Bucket(data.authorImageFile[0]);
+    }
 
     if (data.file?.[0]) {
       imageUrl = await uploadImageToS3Bucket(data.file[0]);
@@ -104,10 +117,12 @@ export default function DeckForm({
       stackId: data.stackId,
       id: deck?.id,
       imageUrl,
+      authorImageUrl,
       creditCostPerQuestion: CREDIT_COST_FEATURE_FLAG
         ? data.creditCostPerQuestion
         : null,
       file: undefined,
+      authorImageFile: undefined,
     });
 
     if (result?.errorMessage) {
@@ -188,6 +203,48 @@ export default function DeckForm({
             {...register("description")}
           />
           <div className="text-destructive">{errors.description?.message}</div>
+        </div>
+        <div className="mb-3">
+          <label className="block mb-1">Deck Author (optional)</label>
+          <textarea
+            className="border-[1px] py-3 px-4 focus:border-aqua focus:outline-none focus:shadow-input focus:shadow-[#6DECAFCC] rounded-md text-xs w-full text-input-gray border-gray min-h-20"
+            {...register("author")}
+          />
+          <div className="text-destructive">{errors.description?.message}</div>
+        </div>
+        <div className="flex flex-col gap-2 mt-2">
+          <label className="block mb-1">Deck Author Image (optional)</label>
+          {!!authorImagePreviewUrl && (
+            <div className="w-[77px] h-[77px] relative overflow-hidden rounded-lg">
+              <Image
+                fill
+                alt="preview-image-stack"
+                src={authorImagePreviewUrl}
+                className="object-cover w-full h-full"
+              />
+            </div>
+          )}
+          {!!authorImagePreviewUrl && (
+            <Button
+              type="button"
+              onClick={() => {
+                setValue("authorImageFile", []);
+                setValue("authorImageUrl", undefined);
+              }}
+              variant="destructive"
+              className="!w-fit !h-[30px]"
+            >
+              Remove
+            </Button>
+          )}
+          <input
+            type="file"
+            accept="image/png, image/jpeg, image/webp"
+            {...register("authorImageFile")}
+          />
+          <div className="text-destructive">
+            {errors.questions && errors.file?.message}
+          </div>{" "}
         </div>
         <div className="mb-3">
           <label className="block mb-1">Footer (optional)</label>

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -83,6 +83,10 @@ export default function DeckForm({
     : authorImage;
 
   const onSubmit = handleSubmit(async (data) => {
+    if (Object.keys(errors).length > 0) {
+      return;
+    }
+
     const questions = await Promise.all(
       data.questions.map(async (question) => {
         let imageUrl = question.imageUrl || "";
@@ -210,7 +214,7 @@ export default function DeckForm({
             className="border-[1px] py-3 px-4 focus:border-aqua focus:outline-none focus:shadow-input focus:shadow-[#6DECAFCC] rounded-md text-xs w-full text-input-gray border-gray min-h-20"
             {...register("author")}
           />
-          <div className="text-destructive">{errors.description?.message}</div>
+          <div className="text-destructive">{errors.author?.message}</div>
         </div>
         <div className="flex flex-col gap-2 mt-2">
           <label className="block mb-1">Deck Author Image (optional)</label>
@@ -243,7 +247,7 @@ export default function DeckForm({
             {...register("authorImageFile")}
           />
           <div className="text-destructive">
-            {errors.questions && errors.file?.message}
+            {errors.questions && errors.authorImageFile?.message}
           </div>{" "}
         </div>
         <div className="mb-3">

--- a/app/components/Leaderboard/Leaderboard.tsx
+++ b/app/components/Leaderboard/Leaderboard.tsx
@@ -142,6 +142,7 @@ const Leaderboard = ({
           <Avatar
             src={loggedUser?.profileSrc || AvatarPlaceholder.src}
             size="medium"
+            className="border-white"
           />
         </div>
         <div className="flex flex-col gap-2 flex-1 justify-center">

--- a/app/components/Navbar/Navbar.tsx
+++ b/app/components/Navbar/Navbar.tsx
@@ -41,7 +41,11 @@ export function Navbar({
       </Link>
       <div className="flex gap-6 items-center">
         <button onClick={openQuickProfile}>
-          <Avatar src={avatarSrc || AvatarPlaceholder.src} size="small" />
+          <Avatar
+            src={avatarSrc || AvatarPlaceholder.src}
+            size="small"
+            className="border-white"
+          />
         </button>
         <QuickViewProfile
           isOpen={isOpen}

--- a/app/components/PollResult/PollResult.tsx
+++ b/app/components/PollResult/PollResult.tsx
@@ -34,7 +34,11 @@ export default function PollResult({
             <div className="text-base text-white my-2">What you predicted</div>
             <div className="flex gap-3.5">
               <div className="bg-purple-500 min-w-10 h-10 flex justify-center items-center text-sm  font-bold rounded-lg">
-                <Avatar src={avatarSrc || AvatarPlaceholder.src} size="small" />
+                <Avatar
+                  src={avatarSrc || AvatarPlaceholder.src}
+                  size="small"
+                  className="border-white"
+                />
               </div>
               {cloneElement(resultProgressComponent, {
                 text: (

--- a/app/components/PreviewDeckCard/PreviewDeckCard.tsx
+++ b/app/components/PreviewDeckCard/PreviewDeckCard.tsx
@@ -1,3 +1,4 @@
+import { Avatar } from "@/app/components/Avatar/Avatar";
 import { DialogTitle } from "@radix-ui/react-dialog";
 import Image from "next/image";
 import { useState } from "react";
@@ -14,6 +15,8 @@ type PreviewDeckCardProps = {
   description?: string | null;
   footer?: string | null;
   imageUrl?: string | null;
+  author?: string | null;
+  authorImageUrl?: string | null;
   totalNumberOfQuestions: number;
   stackImage: string;
   blurData: string | undefined;
@@ -28,6 +31,8 @@ const PreviewDeckCard = ({
   heading,
   description,
   footer,
+  author,
+  authorImageUrl,
   stackImage,
   imageUrl,
   totalNumberOfQuestions,
@@ -69,20 +74,36 @@ const PreviewDeckCard = ({
               Total {totalNumberOfQuestions} card
               {totalNumberOfQuestions > 1 && "s"}
             </p>
+            {CREDIT_COST_FEATURE_FLAG && deckCreditCost !== null ? (
+              <button
+                className="flex items-center rounded-[56px] bg-chomp-blue-light text-xs text-gray-900 font-medium px-2 py-0.5 w-fit z-50"
+                onClick={() => setIsOpen(true)}
+              >
+                <span className="opacity-50 pr-1">Entry </span>
+                {deckCreditCost > 0
+                  ? `${deckCreditCost} Credit${deckCreditCost !== 1 ? "s" : ""}`
+                  : "Free"}
+                <InfoIcon fill="#0d0d0d" />
+              </button>
+            ) : null}
+            <div className="flex gap-2 items-center">
+              {!!authorImageUrl && (
+                <div className="">
+                  <Avatar
+                    size="small"
+                    className="border-purple-200"
+                    src={authorImageUrl}
+                  />
+                </div>
+              )}
+              {!!author && (
+                <p className="text-[12px] font-bold leading-[16.5px]">
+                  By {author}
+                </p>
+              )}
+            </div>
           </div>
         </div>
-        {CREDIT_COST_FEATURE_FLAG && deckCreditCost !== null ? (
-          <button
-            className="flex items-center rounded-[56px] bg-chomp-blue-light text-xs text-gray-900 font-medium px-2 py-0.5 w-fit z-50"
-            onClick={() => setIsOpen(true)}
-          >
-            <span className="opacity-50 pr-1">Entry </span>
-            {deckCreditCost > 0
-              ? `${deckCreditCost} Credit${deckCreditCost !== 1 ? "s" : ""}`
-              : "Free"}
-            <InfoIcon fill="#0d0d0d" />
-          </button>
-        ) : null}
       </div>
       <Drawer
         open={isOpen}

--- a/app/components/Profile/Profile.tsx
+++ b/app/components/Profile/Profile.tsx
@@ -34,11 +34,7 @@ export async function Profile({
       )}
     >
       <div>
-        <Avatar
-          size="extralarge"
-          className="border-purple-500"
-          src={avatarSrc}
-        />
+        <Avatar size="extralarge" className="border-white" src={avatarSrc} />
       </div>
       <div className="flex flex-col  text-white gap-y-4 flex-1">
         <div className="flex items-baseline">

--- a/app/components/ProfileForm/ProfileForm.tsx
+++ b/app/components/ProfileForm/ProfileForm.tsx
@@ -104,6 +104,7 @@ export function ProfileForm({ profile }: ProfileFormProps) {
             <Avatar
               src={isImageRemoved ? AvatarPlaceholder.src : previewUrl!}
               size="oversized"
+              className="border-white"
             />
             <input
               type="file"

--- a/app/components/RankingCard/RankingCard.tsx
+++ b/app/components/RankingCard/RankingCard.tsx
@@ -41,7 +41,7 @@ const RankingCard = ({
         >
           <p className="text-xl">{rank}</p>
         </div>
-        <Avatar src={imageSrc} size="medium" />
+        <Avatar src={imageSrc} size="medium" className="border-white" />
         <p className="ml-6 text-sm">{name}</p>
       </div>
       <p className="text-base font-bold">{value.toLocaleString("en-US")}</p>

--- a/app/components/TransactionProfile/TransactionProfile.tsx
+++ b/app/components/TransactionProfile/TransactionProfile.tsx
@@ -35,7 +35,11 @@ export function TransactionProfile({
       )}
     >
       <Link href="/application">
-        <Avatar size="large" src={avatarSrc || AvatarPlaceholder.src} />
+        <Avatar
+          size="large"
+          src={avatarSrc || AvatarPlaceholder.src}
+          className="border-white"
+        />
       </Link>
       <div className="flex flex-col  text-white text-base gap-y-3 self-center flex-grow">
         {typeof pointAmount === "number" && (

--- a/app/queries/deck.ts
+++ b/app/queries/deck.ts
@@ -173,6 +173,8 @@ export async function getDeckQuestionsForAnswerById(deckId: number) {
         description: deck.description,
         imageUrl: deck.imageUrl,
         footer: deck.footer,
+        author: deck.author,
+        authorImageUrl: deck.authorImageUrl,
       },
       activeFromDate: deck.activeFromDate,
     };
@@ -194,6 +196,8 @@ export async function getDeckQuestionsForAnswerById(deckId: number) {
       description: deck.description,
       imageUrl: deck.imageUrl,
       footer: deck.footer,
+      author: deck.author,
+      authorImageUrl: deck.authorImageUrl,
     },
     activeFromDate: deck.activeFromDate,
   };

--- a/app/schemas/deck.ts
+++ b/app/schemas/deck.ts
@@ -27,6 +27,21 @@ export const deckSchema = z
         }
         return true;
       }, "Only .jpg, .jpeg, .png and .webp formats are supported."),
+    authorImageFile: z
+      .custom<File[]>()
+      .optional()
+      .refine((files) => {
+        if (files && files.length > 0) {
+          return files[0].size <= IMAGE_UPLOAD_SIZES.DEFAULT;
+        }
+        return true;
+      }, `Max image size allowed is ${IMAGE_UPLOAD_SIZE_STRINGS.DEFAULT}.`)
+      .refine((files) => {
+        if (files && files.length > 0) {
+          return IMAGE_VALID_TYPES.includes(files[0].type);
+        }
+        return true;
+      }, "Only .jpg, .jpeg, .png and .webp formats are supported."),
     imageUrl: z
       .string()
       .optional()
@@ -47,6 +62,26 @@ export const deckSchema = z
         },
       ),
     description: z.string().min(5).optional().nullish().or(z.literal("")),
+    author: z.string().min(5).optional().nullish().or(z.literal("")),
+    authorImageUrl: z
+      .string()
+      .optional()
+      .nullable()
+      .refine(
+        (value) => {
+          if (!value) return true;
+
+          try {
+            new URL(value);
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        {
+          message: "Invalid image source",
+        },
+      ),
     footer: z.string().min(5).max(50).optional().nullish().or(z.literal("")),
     tagIds: z.number().array().default([]),
     stackId: z.number().optional().nullish(),

--- a/app/schemas/deck.ts
+++ b/app/schemas/deck.ts
@@ -10,8 +10,15 @@ import {
 export const deckSchema = z
   .object({
     id: z.number().optional(),
-    deck: z.string().min(5),
-    heading: z.string().min(5).optional().nullish().or(z.literal("")),
+    deck: z
+      .string()
+      .min(5, { message: "Deck name must be at least 5 characters long" }),
+    heading: z
+      .string()
+      .min(5, { message: "Deck heading must be at least 5 characters long" })
+      .optional()
+      .nullish()
+      .or(z.literal("")),
     file: z
       .custom<File[]>()
       .optional()
@@ -61,8 +68,24 @@ export const deckSchema = z
           message: "Invalid image source",
         },
       ),
-    description: z.string().min(5).optional().nullish().or(z.literal("")),
-    author: z.string().min(5).optional().nullish().or(z.literal("")),
+    description: z
+      .string()
+      .min(5, {
+        message: "Deck description must be at least 5 characters long",
+      })
+      .optional()
+      .nullish()
+      .or(z.literal("")),
+    author: z
+      .string()
+      .trim()
+      .min(2, { message: "Author name must be at least 2 characters long" })
+      .refine((value) => value.trim().length > 0, {
+        message: "Author name cannot be empty or consist solely of spaces",
+      })
+      .optional()
+      .nullish()
+      .or(z.literal("")),
     authorImageUrl: z
       .string()
       .optional()

--- a/app/screens/DeckScreens/DeckScreen.tsx
+++ b/app/screens/DeckScreens/DeckScreen.tsx
@@ -10,6 +10,8 @@ type DeckScreenProps = {
   deckInfo: {
     heading: string;
     description: string | null;
+    author: string | null;
+    authorImageUrl: string | null;
     footer: string | null;
     imageUrl: string | null;
     totalNumberOfQuestions: number;

--- a/prisma/migrations/20250120180401_add_author_and_author_image_url_in_decks_table/migration.sql
+++ b/prisma/migrations/20250120180401_add_author_and_author_image_url_in_decks_table/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Deck" ADD COLUMN     "author" TEXT,
+ADD COLUMN     "authorImageUrl" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,6 +124,8 @@ model Deck {
   description                 String?
   heading                     String?
   footer                      String?                       @db.VarChar(50)
+  author                      String?
+  authorImageUrl              String?
   MysteryBoxTrigger           MysteryBoxTrigger[]
 }
 


### PR DESCRIPTION
✅ Add Linear ID (e.g., `PROD-123`) to PR title to automatically link issue

- Description
- Link to the task https://linear.app/gator/issue/PROD-682/add-deck-author-to-deck-info-page. 
- Admin should be able to add author name in "Deck Author"section while creating or editing deck.
- Admin should be able to add author image in "Deck Author Image" section while creating or editing deck.
- Both filed are optional
- Validation for image is set to the same "Default image size" that we have through whole app
- Deck author validation is set to minimum 5 chars. We can add upper limit later
- You'll see on many places border colour update, I've updated it to the colours that should be there. But the update was required due to Avatar image default border colour that was overwriting any colour from the outside.
- What are the steps to test that this code is working?
- Migrations for deck table with two new columns
- Screen shots or recordings for UI changes
End results:
- Deck preview state with author image and author name
<img width="776" alt="Screenshot 2025-01-23 at 16 45 48" src="https://github.com/user-attachments/assets/87db6069-5b36-4e5c-a8c2-85457279a332" />
- Deck preview state with author name, but no author image
<img width="776" alt="Screenshot 2025-01-23 at 16 46 26" src="https://github.com/user-attachments/assets/cac7a3f0-be83-420b-823b-a68b76d9ccb0" />
- Deck preview state with author image, but no name
<img width="776" alt="Screenshot 2025-01-23 at 16 48 53" src="https://github.com/user-attachments/assets/20a9f628-c2d3-4c9e-8f64-8c91a559598d" />
- Deck preview state with no author image and no name
<img width="776" alt="Screenshot 2025-01-23 at 16 50 33" src="https://github.com/user-attachments/assets/d42251d6-bead-4999-9058-dbe337affeba" />

For not yet active decks we do not show author data
<img width="776" alt="Screenshot 2025-01-23 at 16 51 18" src="https://github.com/user-attachments/assets/d2676235-f062-4711-b26c-be3326ff9423" />



