### PR TITLE
PROD-741: Credits UI fixes and answer page credits implementation

### DIFF
--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -72,17 +72,23 @@ const RevealAnswerPage = async ({ params }: Props) => {
     questionResponse.MysteryBoxTrigger[0]?.MysteryBox?.MysteryBoxPrize.find(
       (prize) => prize.prizeType == EBoxPrizeType.Credits,
     );
-  const bonkPrize =
-    questionResponse.MysteryBoxTrigger[0]?.MysteryBox?.MysteryBoxPrize.find(
+
+  const bonkPrizes =
+    questionResponse.MysteryBoxTrigger[0]?.MysteryBox?.MysteryBoxPrize.filter(
       (prize) =>
         prize.prizeType == EBoxPrizeType.Token &&
         prize.tokenAddress == bonkAddress,
     );
 
+  const bonkPrizeAmount = bonkPrizes?.reduce(
+    (total, prize) => total + Number(prize.amount ?? 0),
+    0,
+  );
+
   const chompResult = isCreditsQuestion
     ? {
         result: ResultType.Revealed,
-        rewardTokenAmount: Number(bonkPrize?.amount ?? "0"),
+        rewardTokenAmount: bonkPrizeAmount,
         revealNftId: null,
         burnTransactionSignature: null,
         sendTransactionSignature: null,

--- a/app/application/rewards/page.tsx
+++ b/app/application/rewards/page.tsx
@@ -15,14 +15,14 @@ async function Page() {
     const isUserEligibleForValidationReward: boolean =
       !!validationRewardQuestions && validationRewardQuestions.length > 0;
     return (
-      <>
+      <div className="mb-6">
         <ProfileNavigation />
         <MysteryBoxHub
           isUserEligibleForValidationReward={isUserEligibleForValidationReward}
         />
         <hr className="border-gray-600 my-2 p-0" />
         <MysteryBoxHistory />
-      </>
+      </div>
     );
   } else {
     throw new Error("Content Unavailable");

--- a/app/queries/question.ts
+++ b/app/queries/question.ts
@@ -1,3 +1,4 @@
+import { isQuestionCalculatedAndPaidFor } from "@/lib/question";
 import { AnswerStatus, EBoxPrizeType, Prisma } from "@prisma/client";
 import dayjs from "dayjs";
 import { z } from "zod";
@@ -201,7 +202,9 @@ export async function getQuestionWithUserAnswer(questionId: number) {
             include: {
               MysteryBoxPrize: {
                 where: {
-                  prizeType: EBoxPrizeType.Credits,
+                  prizeType: {
+                    in: [EBoxPrizeType.Credits, EBoxPrizeType.Token],
+                  },
                 },
               },
             },
@@ -255,6 +258,11 @@ export async function getQuestionWithUserAnswer(questionId: number) {
     answerCount: question.questionOptions[0].questionAnswers.length,
   });
 
+  const isCalculatedAndPaidFor =
+    question.creditCostPerQuestion !== null
+      ? await isQuestionCalculatedAndPaidFor(userId, question.id)
+      : true;
+
   return {
     ...question,
     chompResults: question.chompResults.map((chompResult) => ({
@@ -269,5 +277,6 @@ export async function getQuestionWithUserAnswer(questionId: number) {
       ...question.questionOptions.find((qo) => qo.id === qop.id),
     })),
     isQuestionRevealable,
+    isCalculatedAndPaidFor,
   };
 }

--- a/components/HistoryNew/QuestionCard.tsx
+++ b/components/HistoryNew/QuestionCard.tsx
@@ -20,27 +20,30 @@ export function QuestionCard({
   indicatorType,
   revealAtDate,
 }: QuestionCardProps) {
-  return (
+  const card = (
     <div className="bg-gray-700 rounded-lg p-3 gap-6 flex flex-col">
       <div className="text-sm font-medium">{title}</div>
 
       <div className="flex justify-between">
         <QuestionCardStatus title={deckTitle} indicatorType={indicatorType} />
-        {indicatorType != "unrevealed" ? (
-          <Link
-            href={`/application/answer/reveal/${questionId}`}
-            className="flex items-center"
-          >
-            <div className="flex items-center justify text-xs text-gray-400 gap-1">
+        <div className="flex items-center justify text-xs text-gray-400 gap-1">
+          {indicatorType != "unrevealed" ? (
+            <>
               <span>View Answer</span> <ChevronRightIcon />
-            </div>
-          </Link>
-        ) : (
-          <div className="flex items-center justify text-xs text-gray-400 gap-1">
-            {revealAtDate !== null && getTimeUntilReveal(revealAtDate)}
-          </div>
-        )}
+            </>
+          ) : (
+            <>{revealAtDate !== null && getTimeUntilReveal(revealAtDate)}</>
+          )}
+        </div>
       </div>
     </div>
+  );
+
+  if (indicatorType == "unrevealed") return card;
+
+  return (
+    <Link href={`/application/answer/reveal/${questionId}`} className="block">
+      {card}
+    </Link>
   );
 }

--- a/components/HistoryNew/QuestionCard.tsx
+++ b/components/HistoryNew/QuestionCard.tsx
@@ -20,6 +20,9 @@ export function QuestionCard({
   indicatorType,
   revealAtDate,
 }: QuestionCardProps) {
+  const canViewAnswer =
+    indicatorType == "correct" || indicatorType == "incorrect";
+
   const card = (
     <div className="bg-gray-700 rounded-lg p-3 gap-6 flex flex-col">
       <div className="text-sm font-medium">{title}</div>
@@ -27,7 +30,7 @@ export function QuestionCard({
       <div className="flex justify-between">
         <QuestionCardStatus title={deckTitle} indicatorType={indicatorType} />
         <div className="flex items-center justify text-xs text-gray-400 gap-1">
-          {indicatorType != "unrevealed" ? (
+          {canViewAnswer ? (
             <>
               <span>View Answer</span> <ChevronRightIcon />
             </>
@@ -39,7 +42,7 @@ export function QuestionCard({
     </div>
   );
 
-  if (indicatorType == "unrevealed") return card;
+  if (!canViewAnswer) return card;
 
   return (
     <Link href={`/application/answer/reveal/${questionId}`} className="block">

--- a/lib/question.ts
+++ b/lib/question.ts
@@ -1,0 +1,61 @@
+import prisma from "@/app/services/prisma";
+
+/**
+ * Determines if the given question was answered and paid for
+ * by the user, and that we have a calculated correct answer.
+ *
+ * @param userId     User ID.
+ * @param questionId Question ID.
+ *
+ * @return result    true/false.
+ */
+export async function isQuestionCalculatedAndPaidFor(
+  userId: string,
+  questionId: number,
+) {
+  const questions = await prisma.$queryRaw<
+    {
+      id: number;
+      answerCount: number;
+    }[]
+  >`
+SELECT
+    q.id,
+    (
+        SELECT COUNT(DISTINCT CONCAT(qa."userId", qo."questionId"))
+        FROM public."QuestionOption" qo
+        JOIN public."QuestionAnswer" qa ON qa."questionOptionId" = qo."id"
+        WHERE qo."questionId" = q."id"
+    ) AS "answerCount"
+FROM
+    public."Question" q
+JOIN
+    public."FungibleAssetTransactionLog" fatl ON q.id = fatl."questionId"
+WHERE
+    q."id" = ${questionId}
+    AND q."revealAtDate" IS NOT NULL
+    AND q."revealAtDate" < NOW()
+    AND EXISTS (
+        SELECT 1
+        FROM public."QuestionOption" qo
+        JOIN public."QuestionAnswer" qa ON qo.id = qa."questionOptionId"
+        WHERE
+            qo."questionId" = q.id
+            AND qa.selected = TRUE
+            AND (qo."calculatedIsCorrect" IS NOT NULL OR qo."calculatedAveragePercentage" IS NOT NULL)
+            AND qa."userId" = ${userId}
+    )
+    AND fatl."userId" = ${userId}
+    AND fatl."change" = -q."creditCostPerQuestion"
+    AND fatl."type" = 'PremiumQuestionCharge'
+    AND fatl."change" < 0;
+`;
+
+  if (!questions.length) return false;
+
+  return (
+    questions[0].answerCount &&
+    questions[0].answerCount >=
+      Number(process.env.MINIMAL_ANSWERS_PER_QUESTION || 0)
+  );
+}


### PR DESCRIPTION
Previously the reveal answer page links were not working. This is because the answer page wasn't set up for credits questions. I've updated the page to accommodate both legacy questions and credits questions, with two caveats:
- The rewards will be zero until the user has claimed a mystery box.
- For credits questions I'm not sure yet how we determine if the user got the second order right (having neither a ChompResult nor a mystery box prize).

The PR also has UI fixes for the rewards history page:
- Makes the entire question clickable instead of just "View Answer".
- Adds margin at the bottom of the page.