### PR TITLE
PROD-689: Automated banned users

### DIFF
--- a/__tests__/actions/threat-level.test.ts
+++ b/__tests__/actions/threat-level.test.ts
@@ -30,18 +30,14 @@ describe("Threat level blocking", () => {
   beforeAll(async () => {
     users = await generateUsers(5);
 
-    await prisma.user.create({ data: { id: users[0].id } });
-    await prisma.user.create({
-      data: { id: users[1].id, threatLevel: EThreatLevelType.Bot },
-    });
-    await prisma.user.create({
-      data: { id: users[2].id, threatLevel: EThreatLevelType.ManualAllow },
-    });
-    await prisma.user.create({
-      data: { id: users[3].id, threatLevel: EThreatLevelType.ManualBlock },
-    });
-    await prisma.user.create({
-      data: { id: users[4].id, threatLevel: EThreatLevelType.PermanentAllow },
+    await prisma.user.createMany({
+      data: [
+        { id: users[0].id },
+        { id: users[1].id, threatLevel: EThreatLevelType.Bot },
+        { id: users[2].id, threatLevel: EThreatLevelType.ManualAllow },
+        { id: users[3].id, threatLevel: EThreatLevelType.ManualBlock },
+        { id: users[4].id, threatLevel: EThreatLevelType.PermanentAllow },
+      ],
     });
   });
 

--- a/__tests__/actions/threat-level.test.ts
+++ b/__tests__/actions/threat-level.test.ts
@@ -34,9 +34,7 @@ describe("Threat level blocking", () => {
       data: [
         { id: users[0].id },
         { id: users[1].id, threatLevel: EThreatLevelType.Bot },
-
         { id: users[2].id, threatLevel: EThreatLevelType.ManualAllow },
-
         { id: users[3].id, threatLevel: EThreatLevelType.ManualBlock },
         { id: users[4].id, threatLevel: EThreatLevelType.PermanentAllow },
       ],
@@ -65,7 +63,7 @@ describe("Threat level blocking", () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_999");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[1].id });
 
-    expect(getCurrentUser).rejects.toThrow(UserThreatLevelDetected);
+    expect(getCurrentUser()).rejects.toThrow(UserThreatLevelDetected);
   });
 
   it("should allow a manually-permitted 'bot' to validate a session", async () => {
@@ -80,7 +78,7 @@ describe("Threat level blocking", () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_777");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[3].id });
 
-    expect(getCurrentUser).rejects.toThrow(UserThreatLevelDetected);
+    expect(getCurrentUser()).rejects.toThrow(UserThreatLevelDetected);
   });
 
   it("should allow a permanently-allowed user to validate a session", async () => {

--- a/__tests__/actions/threat-level.test.ts
+++ b/__tests__/actions/threat-level.test.ts
@@ -30,14 +30,18 @@ describe("Threat level blocking", () => {
   beforeAll(async () => {
     users = await generateUsers(5);
 
-    await prisma.user.createMany({
-      data: [
-        { id: users[0].id },
-        { id: users[1].id, threatLevel: EThreatLevelType.Bot },
-        { id: users[2].id, threatLevel: EThreatLevelType.ManualAllow },
-        { id: users[3].id, threatLevel: EThreatLevelType.ManualBlock },
-        { id: users[4].id, threatLevel: EThreatLevelType.PermanentAllow },
-      ],
+    await prisma.user.create({ data: { id: users[0].id } });
+    await prisma.user.create({
+      data: { id: users[1].id, threatLevel: EThreatLevelType.Bot },
+    });
+    await prisma.user.create({
+      data: { id: users[2].id, threatLevel: EThreatLevelType.ManualAllow },
+    });
+    await prisma.user.create({
+      data: { id: users[3].id, threatLevel: EThreatLevelType.ManualBlock },
+    });
+    await prisma.user.create({
+      data: { id: users[4].id, threatLevel: EThreatLevelType.PermanentAllow },
     });
   });
 

--- a/__tests__/actions/threat-level.test.ts
+++ b/__tests__/actions/threat-level.test.ts
@@ -55,7 +55,7 @@ describe("Threat level blocking", () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_123");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[0].id });
 
-    expect(getCurrentUser()).resolves.not.toThrow(UserThreatLevelDetected);
+    await expect(getCurrentUser()).resolves.not.toThrow(UserThreatLevelDetected);
   });
 
   it("should disallow a bot user to validate a session", async () => {
@@ -63,14 +63,14 @@ describe("Threat level blocking", () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_999");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[1].id });
 
-    expect(getCurrentUser()).rejects.toThrow(UserThreatLevelDetected);
+    await expect(getCurrentUser()).rejects.toThrow(UserThreatLevelDetected);
   });
 
   it("should allow a manually-permitted 'bot' to validate a session", async () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_888");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[2].id });
 
-    expect(getCurrentUser()).resolves.not.toThrow(UserThreatLevelDetected);
+    await expect(getCurrentUser()).resolves.not.toThrow(UserThreatLevelDetected);
   });
 
   it("should disallow a manually-blocked user to validate a session", async () => {
@@ -78,7 +78,7 @@ describe("Threat level blocking", () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_777");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[3].id });
 
-    expect(getCurrentUser()).rejects.toThrow(UserThreatLevelDetected);
+    await expect(getCurrentUser()).rejects.toThrow(UserThreatLevelDetected);
   });
 
   it("should allow a permanently-allowed user to validate a session", async () => {
@@ -86,6 +86,6 @@ describe("Threat level blocking", () => {
     (getTokenFromCookie as jest.Mock).mockResolvedValue("token_222");
     (decodeJwtPayload as jest.Mock).mockResolvedValue({ sub: users[4].id });
 
-    expect(getCurrentUser()).resolves.not.toThrow(UserThreatLevelDetected);
+    await expect(getCurrentUser()).resolves.not.toThrow(UserThreatLevelDetected);
   });
 });

--- a/__tests__/lib/bots.test.ts
+++ b/__tests__/lib/bots.test.ts
@@ -1,0 +1,82 @@
+import prisma from "@/app/services/prisma";
+import { updateBots } from "@/lib/bots";
+import { generateUsers } from "@/scripts/utils";
+
+describe("Update bot list", () => {
+  let users: { username: string; id: string }[] = [];
+  let userIds: string[] = [];
+
+  beforeAll(async () => {
+    users = await generateUsers(8);
+
+    userIds = users.map((user) => user.id);
+
+    await prisma.user.createMany({
+      data: users,
+    });
+
+    await prisma.user.updateMany({
+      data: {
+        threatLevel: "bot",
+      },
+      where: {
+        id: { in: [userIds[0], userIds[1]] },
+      },
+    });
+
+    await prisma.user.updateMany({
+      data: {
+        threatLevel: "manual-allow",
+      },
+      where: {
+        id: { in: [userIds[2], userIds[3]] },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.user.deleteMany({
+      where: {
+        id: {
+          in: userIds,
+        },
+      },
+    });
+  });
+
+  it("should update bot lists", async () => {
+    await updateBots([
+      userIds[0],
+      userIds[1],
+      userIds[2],
+      userIds[3],
+      userIds[4],
+      userIds[5],
+    ]);
+
+    const records = await prisma.user.findMany({
+      select: { id: true, threatLevel: true },
+      where: { id: { in: userIds } },
+    });
+
+    const userState = Object.fromEntries(
+      records.map((user) => [user.id, user.threatLevel]),
+    );
+
+    // Should both still be bot
+    expect(userState[userIds[0]]).toBe("bot");
+    expect(userState[userIds[1]]).toBe("bot");
+
+    // Should both still be manual-allow
+    expect(userState[userIds[2]]).toBe("manual-allow");
+    expect(userState[userIds[3]]).toBe("manual-allow");
+
+    // Should have changed to bot
+    expect(userState[userIds[4]]).toBe("bot");
+    expect(userState[userIds[5]]).toBe("bot");
+
+    // Should be untouched
+    expect(userState[userIds[6]]).toBeNull();
+    expect(userState[userIds[7]]).toBeNull();
+  });
+});

--- a/app/api/cron/detect-bot-activity/route.ts
+++ b/app/api/cron/detect-bot-activity/route.ts
@@ -47,7 +47,11 @@ export async function GET(request: Request) {
     const scores: Record<string, number> = results["mean_bot_score"];
     const botUserIds = Object.keys(scores);
 
-    await updateBots(botUserIds);
+    await updateBots(
+      botUserIds,
+      new Date(results.start_date),
+      new Date(results.end_date),
+    );
 
     return new Response(
       JSON.stringify({

--- a/app/api/cron/detect-bot-activity/route.ts
+++ b/app/api/cron/detect-bot-activity/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: Request) {
     const results = await response.json();
     const response = fetch(
       "https://mechanism-engine.vercel.app/api/chomp/bot-detector",
-      { signal: AbortSignal.timeout(FIVE_MINUTES) },
+      { signal: AbortSignal.timeout(API_TIMEOUT) },
     );
 
     if (!("mean_bot_score" in results) || !results["mean_bot_score"])

--- a/app/api/cron/detect-bot-activity/route.ts
+++ b/app/api/cron/detect-bot-activity/route.ts
@@ -1,7 +1,5 @@
-import { getQuestionsNeedingCorrectAnswer } from "@/app/queries/answers";
-import { calculateCorrectAnswer } from "@/app/utils/algo";
 import { tryAcquireMutex } from "@/app/utils/mutex";
-import { isBotUpdateNeeded, updateBots } from "@/lib/bots";
+import { updateBots } from "@/lib/bots";
 
 const API_TIMEOUT = 5 * 60 * 1000; // Five minutes
 

--- a/app/api/cron/detect-bot-activity/route.ts
+++ b/app/api/cron/detect-bot-activity/route.ts
@@ -1,0 +1,69 @@
+import { getQuestionsNeedingCorrectAnswer } from "@/app/queries/answers";
+import { calculateCorrectAnswer } from "@/app/utils/algo";
+import { tryAcquireMutex } from "@/app/utils/mutex";
+import { isBotUpdateNeeded, updateBots } from "@/lib/bots";
+
+const API_TIMEOUT = 5 * 60 * 1000; // Five minutes
+
+/**
+ * Looks for questions that are revealing soon and submits
+ * them to the bot analysis API, marking any bots that are
+ * returned from the API as bots in the database.
+ */
+export async function GET(request: Request) {
+  const secret = process.env.CRON_SECRET || "";
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${secret}`) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+
+  const release = await tryAcquireMutex({
+    identifier: "DETECT_BOT_ACTIVITY",
+    data: {},
+  });
+
+  if (release === null) {
+    return new Response(
+      JSON.stringify({
+        message: "Activity analysis already in progress",
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  try {
+    const results = await response.json();
+    const response = fetch(
+      "https://mechanism-engine.vercel.app/api/chomp/bot-detector",
+      { signal: AbortSignal.timeout(FIVE_MINUTES) },
+    );
+
+    if (!("mean_bot_score" in results) || !results["mean_bot_score"])
+      throw new Error("Missing field in bot detector API results");
+
+    const scores: Record<string, number> = results["mean_bot_score"];
+    const botUserIds = Object.keys(scores);
+
+    await updateBots(botUserIds);
+
+    return new Response(
+      JSON.stringify({
+        message: "Analysis completed",
+        botCount: botUserIds.length,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  } catch (error) {
+    console.error("Error:", error);
+    return new Response("Internal Server Error", { status: 500 });
+  } finally {
+    release();
+  }
+}

--- a/app/api/cron/detect-bot-activity/route.ts
+++ b/app/api/cron/detect-bot-activity/route.ts
@@ -34,11 +34,12 @@ export async function GET(request: Request) {
   }
 
   try {
-    const results = await response.json();
-    const response = fetch(
+    const response = await fetch(
       "https://mechanism-engine.vercel.app/api/chomp/bot-detector",
       { signal: AbortSignal.timeout(API_TIMEOUT) },
     );
+
+    const results = await response.json();
 
     if (!("mean_bot_score" in results) || !results["mean_bot_score"])
       throw new Error("Missing field in bot detector API results");

--- a/lib/bots.ts
+++ b/lib/bots.ts
@@ -20,6 +20,10 @@ export const updateBots = async (
     where: {
       id: { in: bots },
       threatLevel: EThreatLevelType.ManualAllow,
+      OR: [
+        { threatLevelWindow: null },
+        { threatLevelWindow: { lt: analysisWindowStart } },
+      ],
     },
   });
 

--- a/lib/bots.ts
+++ b/lib/bots.ts
@@ -1,0 +1,13 @@
+import prisma from "@/app/services/prisma";
+
+export const updateBots = async (bots: string[]) => {
+  await prisma.user.updateMany({
+    data: {
+      threatLevel: "bot",
+    },
+    where: {
+      id: { in: bots },
+      threatLevel: null,
+    },
+  });
+};

--- a/lib/bots.ts
+++ b/lib/bots.ts
@@ -1,19 +1,61 @@
+import { SENTRY_FLUSH_WAIT } from "@/app/constants/sentry";
 import prisma from "@/app/services/prisma";
+import { EThreatLevelType } from "@/types/bots";
+import * as Sentry from "@sentry/nextjs";
 
 /**
  * Marks the given list of suspected bot users as
  * bots, without overwriting existing threat levels.
  *
- * @param bots Array of user IDs.
+ * @param bots                Array of user IDs.
+ * @param analysisWindowStart Start of period used for analysis.
+ * @param analysisWindowEnd   End of period used for analysis.
  */
-export const updateBots = async (bots: string[]) => {
+export const updateBots = async (
+  bots: string[],
+  analysisWindowStart: Date,
+  _analysisWindowEnd: Date,
+) => {
+  const reoffenders = await prisma.user.findMany({
+    where: {
+      id: { in: bots },
+      threatLevel: EThreatLevelType.ManualAllow,
+    },
+  });
+
+  if (reoffenders.length > 0) {
+    Sentry.captureMessage(
+      `Bot users marked as "manual-allow" caught reoffending; marking as bots again...`,
+      {
+        level: "info",
+        tags: {
+          category: "reoffending-bots",
+        },
+        extra: {
+          reoffenders,
+        },
+      },
+    );
+    await Sentry.flush(SENTRY_FLUSH_WAIT);
+  }
+
   await prisma.user.updateMany({
     data: {
       threatLevel: "bot",
     },
     where: {
       id: { in: bots },
-      threatLevel: null,
+      AND: [
+        { threatLevel: { not: EThreatLevelType.Bot } },
+        { threatLevel: { not: EThreatLevelType.ManualBlock } },
+        { threatLevel: { not: EThreatLevelType.PermanentAllow } },
+        {
+          OR: [
+            { threatLevelChangedAt: null },
+            { threatLevelChangedAt: { lt: analysisWindowStart } },
+          ],
+        },
+      ],
     },
   });
 };

--- a/lib/bots.ts
+++ b/lib/bots.ts
@@ -14,7 +14,7 @@ import * as Sentry from "@sentry/nextjs";
 export const updateBots = async (
   bots: string[],
   analysisWindowStart: Date,
-  _analysisWindowEnd: Date,
+  analysisWindowEnd: Date,
 ) => {
   const reoffenders = await prisma.user.findMany({
     where: {
@@ -42,6 +42,7 @@ export const updateBots = async (
   await prisma.user.updateMany({
     data: {
       threatLevel: "bot",
+      threatLevelWindow: analysisWindowEnd,
     },
     where: {
       id: { in: bots },
@@ -51,8 +52,8 @@ export const updateBots = async (
         { threatLevel: { not: EThreatLevelType.PermanentAllow } },
         {
           OR: [
-            { threatLevelChangedAt: null },
-            { threatLevelChangedAt: { lt: analysisWindowStart } },
+            { threatLevelWindow: null },
+            { threatLevelWindow: { lt: analysisWindowStart } },
           ],
         },
       ],

--- a/lib/bots.ts
+++ b/lib/bots.ts
@@ -1,5 +1,11 @@
 import prisma from "@/app/services/prisma";
 
+/**
+ * Marks the given list of suspected bot users as
+ * bots, without overwriting existing threat levels.
+ *
+ * @param bots Array of user IDs.
+ */
 export const updateBots = async (bots: string[]) => {
   await prisma.user.updateMany({
     data: {

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -1,11 +1,15 @@
 import prisma from "@/app/services/prisma";
 import { UserThreatLevelDetected } from "@/lib/error";
+import { EThreatLevelType } from "@/types/bots";
 import { cookies } from "next/headers";
 
 export const checkThreatLevel = async (userId: string) => {
   const user = await prisma.user.findFirst({ where: { id: userId } });
   if (!user) throw new Error("User not found");
-  if (user.threatLevel === "bot") {
+  if (
+    user.threatLevel === EThreatLevelType.Bot ||
+    user.threatLevel === EThreatLevelType.ManualBlock
+  ) {
     throw new UserThreatLevelDetected("User threat level detected");
   }
 };

--- a/lib/jwt.ts
+++ b/lib/jwt.ts
@@ -5,7 +5,7 @@ import { cookies } from "next/headers";
 export const checkThreatLevel = async (userId: string) => {
   const user = await prisma.user.findFirst({ where: { id: userId } });
   if (!user) throw new Error("User not found");
-  if (user.threatLevel) {
+  if (user.threatLevel === "bot") {
     throw new UserThreatLevelDetected("User threat level detected");
   }
 };

--- a/prisma/migrations/20250210225409_add_threatlevelchangedat_column/migration.sql
+++ b/prisma/migrations/20250210225409_add_threatlevelchangedat_column/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "User" ADD COLUMN     "threatLevelChangedAt" TIMESTAMP(3);

--- a/prisma/migrations/20250210225409_add_threatlevelchangedat_column/migration.sql
+++ b/prisma/migrations/20250210225409_add_threatlevelchangedat_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "threatLevelChangedAt" TIMESTAMP(3);

--- a/prisma/migrations/20250210225409_add_threatlevelwindow_column/migration.sql
+++ b/prisma/migrations/20250210225409_add_threatlevelwindow_column/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "threatLevelWindow" DATE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   twitterUsername             String?                       @unique
   isBotSubscriber             Boolean                       @default(false)
   threatLevel                 String?
+  threatLevelChangedAt        DateTime?
   MysteryBox                  MysteryBox[]
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,7 @@ model User {
   twitterUsername             String?                       @unique
   isBotSubscriber             Boolean                       @default(false)
   threatLevel                 String?
-  threatLevelChangedAt        DateTime?
+  threatLevelWindow           DateTime?                     @db.Date
   MysteryBox                  MysteryBox[]
 }
 

--- a/types/bots.ts
+++ b/types/bots.ts
@@ -4,7 +4,7 @@ export enum EThreatLevelType {
   Bot = "bot",
 
   // User previously marked as a bot who is
-  // not pardoned but will be blocked again
+  // now pardoned but will be blocked again
   // by the bot checker if they misbehave.
   ManualAllow = "manual-allow",
 

--- a/types/bots.ts
+++ b/types/bots.ts
@@ -1,0 +1,17 @@
+export enum EThreatLevelType {
+  // User marked as bot by automated process;
+  // Not allowed to access the app.
+  Bot = "bot",
+
+  // User previously marked as a bot who is
+  // not pardoned but will be blocked again
+  // by the bot checker if they misbehave.
+  ManualAllow = "manual-allow",
+
+  // User who has been blocked manually
+  ManualBlock = "manual-block",
+
+  // User who is allowed to access the app
+  // and won't be blocked by the bot checker.
+  PermanentAllow = "permanent-allow",
+}

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,10 @@
     {
       "path": "/api/cron/calculate-correct-answers",
       "schedule": "* * * * *"
+    },
+    {
+      "path": "/api/cron/detect-bot-activity",
+      "schedule": "50 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Pulls suspected bot users from the mechanism engine and updates the database.

Runs 10 minutes before every hour so questions that are about to reveal are included in the analysis.

The production endpoint is not deployed yet.