### PR TITLE
PROD-749: User can view revealed answers without participance

### DIFF
--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -115,14 +115,14 @@ const RevealAnswerPage = async ({ params }: Props) => {
       }
     }
 
-    if (!questionResponse.isCalculatedAndPaidFor)
-      return (
-        <NotAvailableYet
-          msg={
-            "Question not answered or answer not calculated yet. Check back shortly."
-          }
-        />
-      );
+    // if (!questionResponse.isCalculatedAndPaidFor)
+    //   return (
+    //     <NotAvailableYet
+    //       msg={
+    //         "Question not answered or answer not calculated yet. Check back shortly."
+    //       }
+    //     />
+    //   );
   } else {
     if (
       !questionResponse.isQuestionRevealable ||

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -228,7 +228,7 @@ export async function getNewHistoryQuery(
     q.question AS "question",
     q."revealAtDate" AS "revealAtDate",
     CASE
-        WHEN COUNT(CASE WHEN qa.selected IS NOT NULL THEN 1 ELSE NULL END) = 0 THEN 'unanswered'
+        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qa.selected IS NOT NULL THEN 1 ELSE NULL END) = 0 THEN 'unanswered'
         WHEN COUNT(CASE WHEN q."revealAtDate" > NOW() THEN 1 ELSE NULL END) > 0 THEN 'unrevealed'
         WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."isCorrect" = true THEN 1 ELSE NULL END) > 0 THEN 'correct'
         WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."isCorrect" = false THEN 1 ELSE NULL END) > 0 THEN 'incorrect'

--- a/components/HistoryNew/QuestionCard.tsx
+++ b/components/HistoryNew/QuestionCard.tsx
@@ -21,7 +21,9 @@ export function QuestionCard({
   revealAtDate,
 }: QuestionCardProps) {
   const canViewAnswer =
-    indicatorType == "correct" || indicatorType == "incorrect";
+    indicatorType == "correct" ||
+    indicatorType == "incorrect" ||
+    indicatorType == "unanswered";
 
   const card = (
     <div className="bg-gray-700 rounded-lg p-3 gap-6 flex flex-col">


### PR DESCRIPTION
User would be able to see answers once reveal date is passed regardless their participance. 
- Applied on history tab each question
- Same with stack > deck > questions