### PR TITLE
PROD-774: update second order report on answer page

### DIFF
--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -22,11 +22,7 @@ import {
   getAlphaIdentifier,
 } from "@/app/utils/question";
 import ViewRewardsButton from "@/components/ViewRewardsButton";
-import {
-  EBoxPrizeType,
-  QuestionType,
-  ResultType,
-} from "@prisma/client";
+import { EBoxPrizeType, QuestionType, ResultType } from "@prisma/client";
 import { isPast } from "date-fns";
 import { notFound } from "next/navigation";
 
@@ -129,8 +125,12 @@ const RevealAnswerPage = async ({ params }: Props) => {
 
   const isFirstOrderCorrect =
     questionResponse.correctAnswer?.id === answerSelected?.questionOptionId;
-  const isSecondOrderCorrect =
-    (chompResult?.rewardTokenAmount ?? 0) > questionResponse.revealTokenAmount;
+  const isSecondOrderCorrect = isCreditsQuestion
+    ? hasAlreadyClaimedReward
+      ? bonkPrizeAmount > 0
+      : undefined
+    : (chompResult?.rewardTokenAmount ?? 0) >
+      questionResponse.revealTokenAmount;
   let questionContent = <></>;
 
   if (isBinary) {

--- a/app/components/PollResult/PollResult.tsx
+++ b/app/components/PollResult/PollResult.tsx
@@ -45,7 +45,11 @@ export default function PollResult({
                   <div
                     className={classNames(
                       "text-aqua text-sm font-bold z-10 flex items-center gap-1",
-                      { "text-destructive": !isCorrect },
+                      { "text-gray-200": isCorrect === undefined },
+                      {
+                        "text-destructive":
+                          isCorrect !== undefined && !isCorrect,
+                      },
                     )}
                   >
                     <div>You guessed {percentageSelected}% for </div>

--- a/app/components/QuestionAnswerLabel/QuestionAnswerLabel.tsx
+++ b/app/components/QuestionAnswerLabel/QuestionAnswerLabel.tsx
@@ -3,7 +3,7 @@ import IncorrectMarkIcon from "../Icons/IncorrectMarkIcon";
 
 type QuestionAnswerLabelProps = {
   label: string;
-  isCorrect: boolean;
+  isCorrect?: boolean;
 };
 
 export default function QuestionAnswerLabel({
@@ -13,7 +13,9 @@ export default function QuestionAnswerLabel({
   return (
     <div className="bg-gray-600 py-2 px-3 rounded-full inline-flex items-center justify-between gap-2">
       <div className="text-white text-xs font-bold leading-4">{label}</div>
-      <div>{isCorrect ? <CheckMarkIcon /> : <IncorrectMarkIcon />}</div>
+      {isCorrect !== undefined && (
+        <div>{isCorrect ? <CheckMarkIcon /> : <IncorrectMarkIcon />}</div>
+      )}
     </div>
   );
 }

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -228,7 +228,7 @@ export async function getNewHistoryQuery(
     q.question AS "question",
     q."revealAtDate" AS "revealAtDate",
     CASE
-        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qa.selected IS NOT NULL THEN 1 ELSE NULL END) = 0 THEN 'unanswered'
+        WHEN COUNT(CASE WHEN qa.selected IS NOT NULL THEN 1 ELSE NULL END) = 0 THEN 'unanswered'
         WHEN COUNT(CASE WHEN q."revealAtDate" > NOW() THEN 1 ELSE NULL END) > 0 THEN 'unrevealed'
         WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."isCorrect" = true THEN 1 ELSE NULL END) > 0 THEN 'correct'
         WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."isCorrect" = false THEN 1 ELSE NULL END) > 0 THEN 'incorrect'

--- a/components/HistoryNew/QuestionCard.tsx
+++ b/components/HistoryNew/QuestionCard.tsx
@@ -1,6 +1,7 @@
 import { ChevronRightIcon } from "@/app/components/Icons/ChevronRightIcon";
 import { getTimeUntilReveal } from "@/app/utils/history";
 import { QuestionCardIndicatorType } from "@/types/question";
+import { isPast } from "date-fns";
 import Link from "next/link";
 
 import { QuestionCardStatus } from "./QuestionCardStatus";
@@ -21,9 +22,11 @@ export function QuestionCard({
   revealAtDate,
 }: QuestionCardProps) {
   const canViewAnswer =
-    indicatorType == "correct" ||
-    indicatorType == "incorrect" ||
-    indicatorType == "unanswered";
+    (indicatorType == "correct" ||
+      indicatorType == "incorrect" ||
+      indicatorType == "unanswered") &&
+    revealAtDate !== null &&
+    isPast(revealAtDate);
 
   const card = (
     <div className="bg-gray-700 rounded-lg p-3 gap-6 flex flex-col">


### PR DESCRIPTION
Show second order result greyed out until we know the result.

The PR also fixes the question card status query which was broken in a recent commit.

Until mystery box is opened:
![secondorder_unknown](https://github.com/user-attachments/assets/acf20457-cd10-4f5e-a5af-56ab147f9e2a)

Post opening:
![secondorder_known](https://github.com/user-attachments/assets/174dc689-97a2-4ce1-9cb7-400d720991d2)
