### PR TITLE
PROD-777: Cleanup test data and Flaky Prisma Error

### DIFF
--- a/__tests__/actions/mystery-box-history.test.ts
+++ b/__tests__/actions/mystery-box-history.test.ts
@@ -221,7 +221,7 @@ describe("Mystery box history", () => {
     });
     await prisma.user.deleteMany({
       where: {
-        id: { in: [user0.id, user1.id] },
+        id: { in: [user0.id, user1.id, user2.id] },
       },
     });
   });

--- a/__tests__/queries/home/deck.test.ts
+++ b/__tests__/queries/home/deck.test.ts
@@ -42,128 +42,135 @@ describe("queryExpiringDecks", () => {
       existingDecks.map((deck) => [deck.id, true]),
     );
 
-    await prisma.$transaction(async (tx) => {
-      // Create decks
-      const decks = await Promise.all([
-        tx.deck.create({
-          data: {
-            deck: "Deck 1",
-            activeFromDate: dayjs().startOf("day").toDate(),
-            revealAtDate: dayjs().add(1, "day").toDate(),
-          },
-        }),
-        tx.deck.create({
-          data: {
-            deck: "Deck 2",
-            activeFromDate: dayjs().startOf("day").toDate(),
-            revealAtDate: dayjs().add(1, "day").toDate(),
-          },
-        }),
-      ]);
+    // Create decks
+    const deckData = [
+      {
+        data: {
+          deck: "Deck 1",
+          activeFromDate: dayjs().startOf("day").toDate(),
+          revealAtDate: dayjs().add(1, "day").toDate(),
+        },
+      },
+      {
+        data: {
+          deck: "Deck 2",
+          activeFromDate: dayjs().startOf("day").toDate(),
+          revealAtDate: dayjs().add(1, "day").toDate(),
+        },
+      },
+    ];
 
-      deckIds = decks.map((deck) => deck.id);
+    const decks = [];
 
-      // Create questions for decks
-      const questions = await Promise.all([
-        tx.question.create({
-          data: {
-            question: "Is the sky blue?",
-            type: QuestionType.BinaryQuestion,
-            revealAtDate: new Date("2024-10-11 16:00:00.000"),
-            revealToken: Token.Bonk,
-            revealTokenAmount: 5000,
-            questionOptions: {
-              createMany: {
-                data: [
-                  {
-                    option: "Yes",
-                    isLeft: true,
-                    calculatedIsCorrect: true,
-                    calculatedPercentageOfSelectedAnswers: 90,
-                    calculatedAveragePercentage: 70,
-                  },
-                  {
-                    option: "No",
-                    isLeft: false,
-                    calculatedIsCorrect: false,
-                    calculatedPercentageOfSelectedAnswers: 10,
-                    calculatedAveragePercentage: 30,
-                  },
-                ],
-              },
+    for (const deck of deckData) {
+      const createdDeck = await prisma.deck.create({
+        data: deck.data,
+      });
+      decks.push(createdDeck);
+    }
+
+    deckIds = decks.map((deck) => deck.id);
+
+    // Create questions for decks
+    const questions = await Promise.all([
+      prisma.question.create({
+        data: {
+          question: "Is the sky blue?",
+          type: QuestionType.BinaryQuestion,
+          revealAtDate: new Date("2024-10-11 16:00:00.000"),
+          revealToken: Token.Bonk,
+          revealTokenAmount: 5000,
+          questionOptions: {
+            createMany: {
+              data: [
+                {
+                  option: "Yes",
+                  isLeft: true,
+                  calculatedIsCorrect: true,
+                  calculatedPercentageOfSelectedAnswers: 90,
+                  calculatedAveragePercentage: 70,
+                },
+                {
+                  option: "No",
+                  isLeft: false,
+                  calculatedIsCorrect: false,
+                  calculatedPercentageOfSelectedAnswers: 10,
+                  calculatedAveragePercentage: 30,
+                },
+              ],
             },
           },
-          include: {
-            questionOptions: true,
-          },
-        }),
-        tx.question.create({
-          data: {
-            question: "Is water wet?",
-            type: QuestionType.BinaryQuestion,
-            revealAtDate: new Date("2024-10-12 16:00:00.000"),
-            revealToken: Token.Bonk,
-            revealTokenAmount: 5000,
-            questionOptions: {
-              createMany: {
-                data: [
-                  {
-                    option: "Yes",
-                    isLeft: true,
-                    calculatedIsCorrect: true,
-                    calculatedPercentageOfSelectedAnswers: 85,
-                    calculatedAveragePercentage: 60,
-                  },
-                  {
-                    option: "No",
-                    isLeft: false,
-                    calculatedIsCorrect: false,
-                    calculatedPercentageOfSelectedAnswers: 15,
-                    calculatedAveragePercentage: 40,
-                  },
-                ],
-              },
+        },
+        include: {
+          questionOptions: true,
+        },
+      }),
+      prisma.question.create({
+        data: {
+          question: "Is water wet?",
+          type: QuestionType.BinaryQuestion,
+          revealAtDate: new Date("2024-10-12 16:00:00.000"),
+          revealToken: Token.Bonk,
+          revealTokenAmount: 5000,
+          questionOptions: {
+            createMany: {
+              data: [
+                {
+                  option: "Yes",
+                  isLeft: true,
+                  calculatedIsCorrect: true,
+                  calculatedPercentageOfSelectedAnswers: 85,
+                  calculatedAveragePercentage: 60,
+                },
+                {
+                  option: "No",
+                  isLeft: false,
+                  calculatedIsCorrect: false,
+                  calculatedPercentageOfSelectedAnswers: 15,
+                  calculatedAveragePercentage: 40,
+                },
+              ],
             },
           },
-          include: {
-            questionOptions: true,
-          },
-        }),
-      ]);
+        },
+        include: {
+          questionOptions: true,
+        },
+      }),
+    ]);
 
-      questionIds = questions.map((q) => q.id);
+    questionIds = questions.map((q) => q.id);
 
-      await tx.deckQuestion.createMany({
-        data: [
-          { deckId: decks[0].id, questionId: questions[0].id },
-          { deckId: decks[1].id, questionId: questions[1].id },
-        ],
-      });
+    await prisma.deckQuestion.createMany({
+      data: [
+        { deckId: decks[0].id, questionId: questions[0].id },
+        { deckId: decks[1].id, questionId: questions[1].id },
+      ],
+    });
 
-      // Create users
-      await Promise.all([
-        tx.user.create({ data: user1 }),
-        tx.user.create({ data: user2 }),
-      ]);
+    // Create users
+    await Promise.all([
+      prisma.user.create({ data: user1 }),
+      prisma.user.create({ data: user2 }),
+    ]);
 
-      // Create answers for user1
-      await tx.questionAnswer.createMany({
-        data: questions.flatMap((question) =>
-          question.questionOptions.map((qo, i) => ({
-            questionOptionId: qo.id,
-            userId: user1.id,
-            selected: i === 0,
-          })),
-        ),
-      });
-
-      await tx.questionAnswer.createMany({
-        data: questions[0].questionOptions.map((qo, i) => ({
+    // Create answers for user1
+    await prisma.questionAnswer.createMany({
+      data: questions.flatMap((question) =>
+        question.questionOptions.map((qo, i) => ({
           questionOptionId: qo.id,
-          userId: user2.id,
+          userId: user1.id,
           selected: i === 0,
         })),
-      });
+      ),
+    });
+
+    await prisma.questionAnswer.createMany({
+      data: questions[0].questionOptions.map((qo, i) => ({
+        questionOptionId: qo.id,
+        userId: user2.id,
+        selected: i === 0,
+      })),
     });
   });
 

--- a/__tests__/queries/home/get-free-deck.test.ts
+++ b/__tests__/queries/home/get-free-deck.test.ts
@@ -1,5 +1,6 @@
 import { deleteDeck } from "@/app/actions/deck/deck";
 import { getFreeDecks } from "@/app/queries/home";
+import { getIsUserAdmin } from "@/app/queries/user";
 import prisma from "@/app/services/prisma";
 import { QuestionType } from "@prisma/client";
 import { v4 as uuidv4 } from "uuid";
@@ -34,6 +35,10 @@ jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
 }));
 
+jest.mock("@/app/queries/user", () => ({
+  getIsUserAdmin: jest.fn().mockResolvedValue(true),
+}));
+
 describe("getPremiumDeck", () => {
   const user1 = {
     id: uuidv4(),
@@ -49,7 +54,7 @@ describe("getPremiumDeck", () => {
     const deckData = [
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -88,7 +93,7 @@ describe("getPremiumDeck", () => {
       },
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
@@ -127,7 +132,7 @@ describe("getPremiumDeck", () => {
       },
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtAnswerCount: null,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -166,7 +171,7 @@ describe("getPremiumDeck", () => {
       },
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -205,7 +210,7 @@ describe("getPremiumDeck", () => {
       },
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
@@ -244,7 +249,7 @@ describe("getPremiumDeck", () => {
       },
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
@@ -283,7 +288,7 @@ describe("getPremiumDeck", () => {
       },
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -323,7 +328,7 @@ describe("getPremiumDeck", () => {
 
       {
         data: {
-          deck: `deck ${new Date().getTime()}`,
+          deck: `Free Deck ${new Date().getTime()}`,
           revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
           activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
           revealAtAnswerCount: null,
@@ -373,6 +378,7 @@ describe("getPremiumDeck", () => {
   });
 
   afterAll(async () => {
+    jest.mocked(getIsUserAdmin).mockResolvedValue(true);
     const deletePromises = deckIds.map((deckId) => deleteDeck(deckId));
     await Promise.all(deletePromises);
 

--- a/__tests__/queries/home/get-free-deck.test.ts
+++ b/__tests__/queries/home/get-free-deck.test.ts
@@ -1,6 +1,5 @@
 import { deleteDeck } from "@/app/actions/deck/deck";
 import { getFreeDecks } from "@/app/queries/home";
-import { getIsUserAdmin } from "@/app/queries/user";
 import prisma from "@/app/services/prisma";
 import { QuestionType } from "@prisma/client";
 import { v4 as uuidv4 } from "uuid";
@@ -33,10 +32,6 @@ jest.mock("next/navigation", () => ({
 }));
 jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
-}));
-
-jest.mock("@/app/queries/user", () => ({
-  getIsUserAdmin: jest.fn().mockResolvedValue(true),
 }));
 
 describe("getPremiumDeck", () => {
@@ -378,7 +373,6 @@ describe("getPremiumDeck", () => {
   });
 
   afterAll(async () => {
-    jest.mocked(getIsUserAdmin).mockResolvedValue(true);
     const deletePromises = deckIds.map((deckId) => deleteDeck(deckId));
     await Promise.all(deletePromises);
 

--- a/__tests__/queries/home/get-premium-deck.test.ts
+++ b/__tests__/queries/home/get-premium-deck.test.ts
@@ -1,6 +1,5 @@
 import { deleteDeck } from "@/app/actions/deck/deck";
 import { getPremiumDecks } from "@/app/queries/home";
-import { getIsUserAdmin } from "@/app/queries/user";
 import prisma from "@/app/services/prisma";
 import { QuestionType } from "@prisma/client";
 import { v4 as uuidv4 } from "uuid";
@@ -33,10 +32,6 @@ jest.mock("next/navigation", () => ({
 }));
 jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
-}));
-
-jest.mock("@/app/queries/user", () => ({
-  getIsUserAdmin: jest.fn().mockResolvedValue(true),
 }));
 
 describe("getPremiumDeck", () => {
@@ -389,7 +384,6 @@ describe("getPremiumDeck", () => {
   });
 
   afterAll(async () => {
-    jest.mocked(getIsUserAdmin).mockResolvedValue(true);
     const deletePromises = deckIds.map((deckId) => deleteDeck(deckId));
     await Promise.all(deletePromises);
 

--- a/__tests__/queries/home/get-premium-deck.test.ts
+++ b/__tests__/queries/home/get-premium-deck.test.ts
@@ -1,6 +1,8 @@
 import { deleteDeck } from "@/app/actions/deck/deck";
 import { getPremiumDecks } from "@/app/queries/home";
+import { getIsUserAdmin } from "@/app/queries/user";
 import prisma from "@/app/services/prisma";
+import { QuestionType } from "@prisma/client";
 import { v4 as uuidv4 } from "uuid";
 
 jest.mock("@/lib/auth", () => ({
@@ -33,6 +35,10 @@ jest.mock("next/cache", () => ({
   revalidatePath: jest.fn(),
 }));
 
+jest.mock("@/app/queries/user", () => ({
+  getIsUserAdmin: jest.fn().mockResolvedValue(true),
+}));
+
 describe("getPremiumDeck", () => {
   const user1 = {
     id: uuidv4(),
@@ -42,348 +48,355 @@ describe("getPremiumDeck", () => {
   let deckIds: number[] = [];
 
   beforeAll(async () => {
-    await prisma.$transaction(async (tx) => {
-      // Create users
-      await Promise.all([tx.user.create({ data: user1 })]);
+    // Create users
+    await prisma.user.create({ data: user1 });
 
-      // Create decks
-      const decks = await Promise.all([
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 1",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    durationMiliseconds: BigInt(60000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+    // Create decks
+    const decksData = [
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 1",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  durationMiliseconds: BigInt(60000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            revealAtAnswerCount: 2,
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 2",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtAnswerCount: 2,
-                    durationMiliseconds: BigInt(60000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          revealAtAnswerCount: 2,
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 2",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtAnswerCount: 2,
+                  durationMiliseconds: BigInt(60000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtAnswerCount: 3,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 3",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtAnswerCount: 3,
-                    creditCostPerQuestion: 1,
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    durationMiliseconds: BigInt(60000),
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtAnswerCount: 3,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 3",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtAnswerCount: 3,
+                  creditCostPerQuestion: 1,
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  durationMiliseconds: BigInt(60000),
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 4",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    durationMiliseconds: BigInt(60000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 4",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  durationMiliseconds: BigInt(60000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            revealAtAnswerCount: 2,
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 5",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtAnswerCount: 2,
-                    durationMiliseconds: BigInt(60000),
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          revealAtAnswerCount: 2,
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 5",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtAnswerCount: 2,
+                  durationMiliseconds: BigInt(60000),
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            revealAtAnswerCount: 3,
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 6",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtAnswerCount: 3,
-                    durationMiliseconds: BigInt(60000),
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          revealAtAnswerCount: 3,
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 6",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtAnswerCount: 3,
+                  durationMiliseconds: BigInt(60000),
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 7",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    durationMiliseconds: BigInt(60000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 7",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  durationMiliseconds: BigInt(60000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-        await tx.deck.create({
-          data: {
-            deck: `deck ${new Date().getTime()}`,
-            revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-            activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
-            revealAtAnswerCount: 2,
-            deckQuestions: {
-              create: {
-                question: {
-                  create: {
-                    stackId: null,
-                    question: "Question 8",
-                    type: "BinaryQuestion",
-                    revealTokenAmount: 10,
-                    revealAtAnswerCount: 2,
-                    durationMiliseconds: BigInt(60000),
-                    revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
-                    creditCostPerQuestion: 1,
-                    questionOptions: {
-                      create: [
-                        {
-                          option: "A",
-                          isCorrect: true,
-                          isLeft: false,
-                        },
-                        {
-                          option: "B",
-                          isCorrect: false,
-                          isLeft: false,
-                        },
-                      ],
-                    },
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+      {
+        data: {
+          deck: `Premium Deck ${new Date().getTime()}`,
+          revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+          activeFromDate: new Date(Date.now() - 24 * 60 * 60 * 1000),
+          revealAtAnswerCount: 2,
+          deckQuestions: {
+            create: {
+              question: {
+                create: {
+                  stackId: null,
+                  question: "Question 8",
+                  type: QuestionType.BinaryQuestion,
+                  revealTokenAmount: 10,
+                  revealAtAnswerCount: 2,
+                  durationMiliseconds: BigInt(60000),
+                  revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+                  creditCostPerQuestion: 1,
+                  questionOptions: {
+                    create: [
+                      {
+                        option: "A",
+                        isCorrect: true,
+                        isLeft: false,
+                      },
+                      {
+                        option: "B",
+                        isCorrect: false,
+                        isLeft: false,
+                      },
+                    ],
                   },
                 },
               },
             },
           },
-          include: {
-            deckQuestions: true,
-          },
-        }),
-      ]);
+        },
+        include: {
+          deckQuestions: true,
+        },
+      },
+    ];
 
-      deckIds = decks.map((deck) => deck.id);
-    });
+    const decks = [];
+
+    for (let i = 0; i < decksData.length; i++) {
+      const deck = await prisma.deck.create({
+        data: decksData[i].data,
+        include: decksData[i].include,
+      });
+      decks.push(deck);
+    }
+
+    deckIds = decks.map((deck) => deck.id);
   });
 
   afterAll(async () => {
-    await prisma.$transaction(async () => {
-      const deletePromises = deckIds.map((deckId) => deleteDeck(deckId));
-      await Promise.all(deletePromises);
+    jest.mocked(getIsUserAdmin).mockResolvedValue(true);
+    const deletePromises = deckIds.map((deckId) => deleteDeck(deckId));
+    await Promise.all(deletePromises);
 
-      await prisma.user.deleteMany({
-        where: {
-          id: user1.id,
-        },
-      });
+    await prisma.user.deleteMany({
+      where: {
+        id: user1.id,
+      },
     });
   });
 


### PR DESCRIPTION
Get Premium Deck and Free Deck tests were giving flaky Transaction API prisma error (couldn't able to start in given time). Patch to fix this issue and cleanup data after test is completed.

Other tests didn't delete data and stale data is piling up in the db. I audited those tests and sanitized all the stale crops.
