### PR TITLE
PROD-809: Empty mystery boxes should disappear until new reaveals ready

### DIFF
--- a/app/actions/mysteryBox/rewardMysteryBoxHub.ts
+++ b/app/actions/mysteryBox/rewardMysteryBoxHub.ts
@@ -8,6 +8,7 @@ import {
   EBoxPrizeStatus,
   EBoxPrizeType,
   EBoxTriggerType,
+  EMysteryBoxStatus,
   EPrizeSize,
 } from "@prisma/client";
 
@@ -49,6 +50,9 @@ export const rewardMysteryBoxHub = async ({
       triggerType: EBoxTriggerType.ValidationReward,
       MysteryBoxPrize: {
         some: { status: EBoxPrizeStatus.Unclaimed },
+      },
+      MysteryBox: {
+        status: { in: [EMysteryBoxStatus.New, EMysteryBoxStatus.Unopened] },
       },
     },
   });

--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -105,6 +105,8 @@ const RevealAnswerPage = async ({ params }: Props) => {
   const sendTransactionSignature =
     chompResult?.sendTransactionSignature ?? null;
 
+  const isPracticeQuestion = questionResponse.creditCostPerQuestion === 0;
+
   if (!questionResponse.isQuestionRevealable) {
     if (
       questionResponse.revealAtDate === null ||
@@ -346,12 +348,15 @@ const RevealAnswerPage = async ({ params }: Props) => {
           questions={[questionResponse.question]}
           revealAmount={questionResponse.revealTokenAmount}
           creditsRewardAmount={creditsPrize?.amount}
+          isPracticeQuestion={isPracticeQuestion}
         />
       )}
       {questionContent}
       {answerContent}
       <ViewRewardsButton
-        disabled={!isFirstOrderCorrect || hasAlreadyClaimedReward}
+        disabled={
+          !isFirstOrderCorrect || hasAlreadyClaimedReward || isPracticeQuestion
+        }
       />
       {!!chompResult.rewardTokenAmount &&
         chompResult.burnTransactionSignature && (

--- a/app/components/RewardShow/RewardShow.tsx
+++ b/app/components/RewardShow/RewardShow.tsx
@@ -17,6 +17,7 @@ interface RewardShowProps {
   questions: string[];
   revealAmount: number;
   creditsRewardAmount: string | undefined;
+  isPracticeQuestion: boolean;
 }
 
 const RewardShow = ({
@@ -24,6 +25,7 @@ const RewardShow = ({
   isSecondOrderCorrect,
   rewardAmount,
   creditsRewardAmount,
+  isPracticeQuestion,
 }: RewardShowProps) => {
   if (isFirstOrderCorrect) {
     return (
@@ -34,28 +36,34 @@ const RewardShow = ({
               ? "Congrats, you won!"
               : "Well done!"}
           </span>
-          <div className="h-[1px] w-full bg-gray-500" />
-          {isSecondOrderCorrect !== undefined ? (
-            <div className="flex items-center gap-1 justify-between">
-              <p className="text-sm font-normal  text-left">Claim reward:</p>
-              <Pill variant="white">
-                <p className="text-xs font-bold text-center">
-                  {numberToCurrencyFormatter.format(
-                    Math.round(rewardAmount || 0),
-                  )}{" "}
-                  BONK
-                </p>
-              </Pill>
-              <Pill variant="white">
-                <p className="text-xs font-bold text-center">
-                  {Number(creditsRewardAmount) || 0} CREDITS
-                </p>
-              </Pill>
-            </div>
-          ) : (
-            <div className="flex items-center gap-1 justify-between">
-              View your rewards below.
-            </div>
+          {!isPracticeQuestion && (
+            <>
+              <div className="h-[1px] w-full bg-gray-500" />
+              {isSecondOrderCorrect !== undefined ? (
+                <div className="flex items-center gap-1 justify-between">
+                  <p className="text-sm font-normal  text-left">
+                    Claim reward:
+                  </p>
+                  <Pill variant="white">
+                    <p className="text-xs font-bold text-center">
+                      {numberToCurrencyFormatter.format(
+                        Math.round(rewardAmount || 0),
+                      )}{" "}
+                      BONK
+                    </p>
+                  </Pill>
+                  <Pill variant="white">
+                    <p className="text-xs font-bold text-center">
+                      {Number(creditsRewardAmount) || 0} CREDITS
+                    </p>
+                  </Pill>
+                </div>
+              ) : (
+                <div className="flex items-center gap-1 justify-between">
+                  View your rewards below.
+                </div>
+              )}
+            </>
           )}
         </div>
         <Trophy width={70} height={85} />


### PR DESCRIPTION
This fixes an issue where the rewards hub shows a claimable mystery box, but claiming it does nothing.

Prizes are fetched based on the prizes being in an unclaimed state, even if the box is marked as opened. I'm not sure why the box state and prize state are not in sync but this update resolves the issue for now.

I also updated the answer page for practice questions as the page implied there could be rewards previously.