### PR TITLE
PROD-813: Fix rewards display on answer page

### DIFF
--- a/app/queries/question.ts
+++ b/app/queries/question.ts
@@ -193,6 +193,9 @@ export async function getQuestionWithUserAnswer(questionId: number) {
       MysteryBoxTrigger: {
         where: {
           questionId,
+          MysteryBox: {
+            userId,
+          },
         },
         include: {
           MysteryBoxPrize: {


### PR DESCRIPTION
Fix rewards display on answer page by not pulling mystery box records for all users.