### PR TITLE
PROD-613: Add ignore sentry error

### DIFF
--- a/app/utils/sentry.ts
+++ b/app/utils/sentry.ts
@@ -10,4 +10,5 @@ export const ignoreErrors = [
   "t.json is not a function. (In 't.json()', 't.json' is undefined)",
   "User is having trouble logging in: [object Object]",
   "Cannot assign to read only property 'request' of object '#<c>'",
+  "Cannot assign to read only property 'request' of object '#<u>'",
 ];


### PR DESCRIPTION
This error was previously ignored, but due to a change in the request object type, it now reflects that change in a similar error.