### PR TITLE
PROD-805: Auto populate revealTokenAmount input in admin panel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,6 @@ NEXT_PUBLIC_SOLANA_COST_PER_CREDIT=
 
 # Mechanism engine base URL
 MECHANISM_ENGINE_URL=
+
+# Default BONK/credit reward in admin panel
+NEXT_PUBLIC_BONK_PER_CREDIT=5000

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -31,6 +31,8 @@ type DeckFormProps = {
 const CREDIT_COST_FEATURE_FLAG =
   process.env.NEXT_PUBLIC_FF_CREDIT_COST_PER_QUESTION;
 
+const BONK_PER_CREDIT = Number(process.env.NEXT_PUBLIC_BONK_PER_CREDIT ?? 5000);
+
 export default function DeckForm({
   deck,
   tags,
@@ -47,6 +49,7 @@ export default function DeckForm({
     watch,
     setValue,
     control,
+    getFieldState,
   } = useForm({
     resolver: zodResolver(deckSchema),
     defaultValues: deck || {
@@ -456,7 +459,7 @@ export default function DeckForm({
           variant="secondary"
           {...register("revealTokenAmount", {
             setValueAs: (v) => (!v ? 0 : parseInt(v)),
-            value: 5000,
+            value: BONK_PER_CREDIT,
           })}
         />
         <div className="text-destructive">
@@ -563,6 +566,13 @@ export default function DeckForm({
             className="text-gray-800 w-full"
             {...register("creditCostPerQuestion", {
               setValueAs: (v) => (!v ? null : parseInt(v)),
+              onChange: (e) => {
+                if (!getFieldState("revealTokenAmount").isDirty)
+                  setValue(
+                    "revealTokenAmount",
+                    e.target.value * BONK_PER_CREDIT,
+                  );
+              },
             })}
           >
             {Array.from({ length: 6 }, (_, i) => i).map((i) => (

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -459,7 +459,7 @@ export default function DeckForm({
           variant="secondary"
           {...register("revealTokenAmount", {
             setValueAs: (v) => (!v ? 0 : parseInt(v)),
-            value: BONK_PER_CREDIT,
+            value: 0,
           })}
         />
         <div className="text-destructive">

--- a/app/utils/algo.ts
+++ b/app/utils/algo.ts
@@ -243,6 +243,7 @@ export const calculateReward = async (
       second_order_mean: 0,
       second_order_estimates: [0],
       question_cost: 0,
+      token_reward: 0,
     };
 
     const correctOptionIndex = question.questionOptions.findIndex(
@@ -284,7 +285,8 @@ export const calculateReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates,
-        question_cost: question.revealTokenAmount,
+        question_cost: question.creditCostPerQuestion ?? 0,
+        token_reward: question.revealTokenAmount,
       };
     }
 
@@ -402,6 +404,11 @@ export const calculateMysteryBoxHubReward = async (
       )
       .find((answer) => answer.userId === userId && answer.selected);
 
+    if (question.creditCostPerQuestion === null)
+      new Error(
+        "Mechanism engine: unable to calculate reward for legacy question",
+      );
+
     if (!userAnswer) {
       questionRewards.push({
         questionId: question.id,
@@ -418,6 +425,7 @@ export const calculateMysteryBoxHubReward = async (
       second_order_mean: 0,
       second_order_estimates: [0],
       question_cost: 0,
+      token_reward: 0,
     };
 
     const correctOptionIndex = question.questionOptions.findIndex(
@@ -459,7 +467,8 @@ export const calculateMysteryBoxHubReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates,
-        question_cost: question.revealTokenAmount,
+        question_cost: question.creditCostPerQuestion ?? 0,
+        token_reward: question.revealTokenAmount,
       };
     }
 
@@ -494,7 +503,8 @@ export const calculateMysteryBoxHubReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates: second_order_estimates,
-        question_cost: question.revealTokenAmount,
+        question_cost: question.creditCostPerQuestion ?? 0,
+        token_reward: question.revealTokenAmount,
       };
     }
 

--- a/app/utils/algo.ts
+++ b/app/utils/algo.ts
@@ -321,7 +321,8 @@ export const calculateReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates: second_order_estimates,
-        question_cost: question.revealTokenAmount,
+        question_cost: question.creditCostPerQuestion ?? 0,
+        token_reward: question.revealTokenAmount,
       };
     }
 

--- a/app/utils/algo.ts
+++ b/app/utils/algo.ts
@@ -215,6 +215,11 @@ export const calculateReward = async (
   }[] = [];
 
   for (const question of questions) {
+    if (question.creditCostPerQuestion === null)
+      throw new Error(
+        "Mechanism engine: unable to calculate reward for legacy question",
+      );
+
     const optionsList = question.questionOptions.map((option) => option.id);
     const inputList = ["a", "b", "c", "d", "e", "f", "g"];
 
@@ -285,7 +290,7 @@ export const calculateReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates,
-        question_cost: question.creditCostPerQuestion ?? 0,
+        question_cost: question.creditCostPerQuestion,
         token_reward: question.revealTokenAmount,
       };
     }
@@ -321,7 +326,7 @@ export const calculateReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates: second_order_estimates,
-        question_cost: question.creditCostPerQuestion ?? 0,
+        question_cost: question.creditCostPerQuestion,
         token_reward: question.revealTokenAmount,
       };
     }
@@ -393,6 +398,11 @@ export const calculateMysteryBoxHubReward = async (
   }[] = [];
 
   for (const question of questions) {
+    if (question.creditCostPerQuestion === null)
+      throw new Error(
+        "Mechanism engine: unable to calculate reward for legacy question",
+      );
+
     const optionsList = question.questionOptions.map((option) => option.id);
     const inputList = ["a", "b", "c", "d", "e", "f", "g"];
 
@@ -404,11 +414,6 @@ export const calculateMysteryBoxHubReward = async (
           : answer,
       )
       .find((answer) => answer.userId === userId && answer.selected);
-
-    if (question.creditCostPerQuestion === null)
-      new Error(
-        "Mechanism engine: unable to calculate reward for legacy question",
-      );
 
     if (!userAnswer) {
       questionRewards.push({
@@ -468,7 +473,7 @@ export const calculateMysteryBoxHubReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates,
-        question_cost: question.creditCostPerQuestion ?? 0,
+        question_cost: question.creditCostPerQuestion,
         token_reward: question.revealTokenAmount,
       };
     }
@@ -504,7 +509,7 @@ export const calculateMysteryBoxHubReward = async (
           questionOption?.calculatedAveragePercentage ??
           getAverage(second_order_estimates),
         second_order_estimates: second_order_estimates,
-        question_cost: question.creditCostPerQuestion ?? 0,
+        question_cost: question.creditCostPerQuestion,
         token_reward: question.revealTokenAmount,
       };
     }

--- a/app/utils/algo.ts
+++ b/app/utils/algo.ts
@@ -514,7 +514,7 @@ export const calculateMysteryBoxHubReward = async (
       };
     }
 
-    const rewards = await getMechanismEngineResponse("v2/rewards", body);
+    const rewards = await getMechanismEngineResponse("/rewards", body);
 
     questionRewards.push({
       questionId: question.id,


### PR DESCRIPTION
- Auto populate `revealTokenAmount` input in admin panel unless manually set.
- Send cost and reveal amounts to mechanism engine.

This update will need to be coordinated with the mechanism engine as we are changing a parameter's meaning and expected value by orders of magnitude.