### PR TITLE
PROD-843: Fix null CPQ on update deck

### DIFF
--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -60,6 +60,7 @@ export default function DeckForm({
           file: [],
         },
       ],
+      creditCostPerQuestion: 0,
     },
   });
   const { fields, append, remove } = useFieldArray({
@@ -565,7 +566,7 @@ export default function DeckForm({
           <select
             className="text-gray-800 w-full"
             {...register("creditCostPerQuestion", {
-              setValueAs: (v) => (!v ? null : parseInt(v)),
+              setValueAs: (v) => (!v ? 0 : parseInt(v)),
               onChange: (e) => {
                 if (!getFieldState("revealTokenAmount").isDirty)
                   setValue(


### PR DESCRIPTION
Reproduce: 
- Create New Practice deck
- Update footer or any property 
- CPQ shouldn't be null

Validate Deck didn't have this issue