### PR TITLE
Prod 844/history tab fix

### DIFF
--- a/__tests__/queries/history/get-new-history-query.test.ts
+++ b/__tests__/queries/history/get-new-history-query.test.ts
@@ -150,19 +150,15 @@ describe("getNewHistoryQuery", () => {
     });
   });
 
-  it("should return unrevealed indicator type", async () => {
-    const result = await getNewHistoryQuery(userIds[0], 1, 1);
-
-    expect(result[0]).toBeDefined();
-    expect(result[0]).toEqual(
-      expect.objectContaining({
-        id: questionId,
-        indicatorType: "unrevealed",
-      }),
-    );
-  });
-
   it("should return unanswered indicator type", async () => {
+    await prisma.question.update({
+      where: {
+        id: questionId,
+      },
+      data: {
+        revealAtDate: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
+      },
+    });
     const result = await getNewHistoryQuery("mock-id", 1, 1);
 
     expect(result).toBeDefined();
@@ -175,15 +171,6 @@ describe("getNewHistoryQuery", () => {
   });
 
   it("should return correct indicator type", async () => {
-    await prisma.question.update({
-      where: {
-        id: questionId,
-      },
-      data: {
-        revealAtDate: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000),
-      },
-    });
-
     await prisma.questionOption.update({
       where: {
         id: questionOptionIds[0],
@@ -208,6 +195,8 @@ describe("getNewHistoryQuery", () => {
         selected: true,
       },
     });
+
+    console.log(answer);
 
     const result = await getNewHistoryQuery(answer?.userId, 1, 1);
 

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -229,8 +229,8 @@ export async function getNewHistoryQuery(
     q."revealAtDate" AS "revealAtDate",
     CASE
         WHEN COUNT(CASE WHEN qa.selected IS NOT NULL THEN 1 ELSE NULL END) = 0 THEN 'unanswered'
-        WHEN COUNT(CASE WHEN qo.id = qa."questionOptionId" AND qo."isCorrect" = true THEN 1 ELSE NULL END) > 0 THEN 'correct'
-        WHEN COUNT(CASE WHEN qo.id = qa."questionOptionId" AND qo."isCorrect" = false THEN 1 ELSE NULL END) > 0 THEN 'incorrect'
+        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."calculatedIsCorrect" = true AND qa."selected" = true THEN 1 ELSE NULL END) > 0 THEN 'correct'
+        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."calculatedIsCorrect" != qa."selected" THEN 1 ELSE NULL END) > 0 THEN 'incorrect'
     END AS "indicatorType"
 FROM "Question" q
          JOIN
@@ -268,8 +268,8 @@ export async function getHistoryHeadersData(
     CASE
         WHEN COUNT(CASE WHEN qa.selected IS NOT NULL THEN 1 ELSE NULL END) = 0 THEN 'unanswered'
         WHEN COUNT(CASE WHEN q."revealAtDate" > NOW() THEN 1 ELSE NULL END) > 0 THEN 'unrevealed'
-        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."isCorrect" = true THEN 1 ELSE NULL END) > 0 THEN 'correct'
-        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."isCorrect" = false THEN 1 ELSE NULL END) > 0 THEN 'incorrect'
+        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."calculatedIsCorrect" = true AND qa."selected" = true THEN 1 ELSE NULL END) > 0 THEN 'correct'
+        WHEN COUNT(CASE WHEN q."revealAtDate" <= NOW() AND qo.id = qa."questionOptionId" AND qo."calculatedIsCorrect" != qa."selected" THEN 1 ELSE NULL END) > 0 THEN 'incorrect'
     END AS questionStatus
 FROM "Question" q
          JOIN


### PR DESCRIPTION
The commit update the query to not show data with future reveal date but mistakenly undo the previous changes 
https://github.com/gator-labs/chomp/commit/8d0b1e58d07b957df88de7d938257c15aa0546f6

This Pr will add the changes back and update the test. 