### PR TITLE
PROD-849: Fix Open MysteryBox Hub

### DIFF
--- a/app/actions/claim.ts
+++ b/app/actions/claim.ts
@@ -183,7 +183,6 @@ export async function claimQuestions(questionIds: number[]) {
     resultIds = chompResults.map((r) => r.id);
     sendTx = await sendClaimedBonkFromTreasury(
       chompResults,
-      questionIds,
       userWallet.address,
     );
 

--- a/app/actions/mysteryBox/open.ts
+++ b/app/actions/mysteryBox/open.ts
@@ -2,7 +2,7 @@
 
 import { getTreasuryAddress } from "@/actions/getTreasuryAddress";
 import { SENTRY_FLUSH_WAIT } from "@/app/constants/sentry";
-import { OpenMysteryBoxError, SendBonkError } from "@/lib/error";
+import { OpenMysteryBoxError } from "@/lib/error";
 import { sendBonkFromTreasury } from "@/lib/mysteryBox";
 import { FungibleAsset, TransactionLogType } from "@prisma/client";
 import {
@@ -140,24 +140,10 @@ export async function openMysteryBox(
           sendTx = await sendBonkFromTreasury(prizeAmount, userWallet.address);
 
           if (!sendTx) {
-            const sendBonkError = new SendBonkError(
-              `User with id: ${payload.sub} (wallet: ${userWallet.address}) is having trouble claiming for Mystery Box: ${mysteryBoxId}`,
-              { cause: "Failed to send bonk" },
-            );
-            Sentry.captureException(sendBonkError, {
-              level: "fatal",
-              tags: {
-                category: "mystery-box-tx-confirmation-error",
-              },
-              extra: {
-                transactionHash: sendTx,
-              },
-            });
+            throw new Error("Send bonk transaction failed");
           } else {
             txHashes[prize.tokenAddress] = sendTx;
           }
-        } else {
-          sendTx = null;
         }
       }
 

--- a/app/actions/mysteryBox/open.ts
+++ b/app/actions/mysteryBox/open.ts
@@ -252,13 +252,14 @@ export async function openMysteryBox(
         mysteryBoxId,
         userId: payload.sub,
         walletAddress: userWallet.address,
+        prizeId: reward.triggers[0].MysteryBoxPrize[0].id,
         error: e,
       },
     });
     throw new Error("Error processing mystery box prizes");
   } finally {
-    release();
     await Sentry.flush(SENTRY_FLUSH_WAIT);
+    release();
   }
 
   return txHashes;

--- a/lib/claim.ts
+++ b/lib/claim.ts
@@ -1,12 +1,11 @@
 "use server";
 
-import { sendBonk } from "@/app/utils/claim";
+import { sendBonk } from "@/app/utils/sendBonk";
 import { ChompResult } from "@prisma/client";
 import { PublicKey } from "@solana/web3.js";
 
 export async function sendClaimedBonkFromTreasury(
   chompResults: ChompResult[],
-  questionIds: number[],
   address: string,
 ) {
   const tokenAmount = chompResults.reduce(
@@ -18,8 +17,6 @@ export async function sendClaimedBonkFromTreasury(
     const sendTx = await sendBonk(
       new PublicKey(address),
       Math.round(tokenAmount * 10 ** 5),
-      chompResults,
-      questionIds,
     );
     return sendTx;
   }

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -58,6 +58,12 @@ export class OpenMysteryBoxError extends Error {
   }
 }
 
+export class OpenMysteryBoxHubError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "OpenMysteryBoxHubError";
+  }
+}
 export class SendBonkError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
@@ -103,13 +109,6 @@ export class UserAllowlistError extends Error {
   constructor(message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "UserAllowlistError";
-  }
-}
-
-export class GetUnopenedMysteryBoxError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
-    super(message, options);
-    this.name = "GetUnopenedMysteryBoxError";
   }
 }
 

--- a/lib/mysteryBox.ts
+++ b/lib/mysteryBox.ts
@@ -4,7 +4,7 @@ import { getJwtPayload } from "@/app/actions/jwt";
 import { SENTRY_FLUSH_WAIT } from "@/app/constants/sentry";
 import { getCurrentUser } from "@/app/queries/user";
 import prisma from "@/app/services/prisma";
-import { sendBonk } from "@/app/utils/claim";
+import { sendBonk } from "@/app/utils/sendBonk";
 import { FindMysteryBoxError } from "@/lib/error";
 import { EBoxTriggerType, EMysteryBoxStatus } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";


### PR DESCRIPTION
- openMysteryBoxHub query validate that MBP should be unclaimed or dismissed
- It will allow new or unopened MB with unclaimed or dismissed MBP
- Better Error Handling in openMysteryBoxHub action and sendBonk util
- Fix FATL update query to handle values
- Add retry logic if prisma tx API fails
- Add similar sanity check on transaction confirmation verification like credit payment to capture tx simulation failure

Few changes won't be related but I changed utils/claim.ts --> utils/sendBonk.ts so legacy mysteryBox code is refactored.