### PR TITLE
fix: only show validation and combined mb in history

### DIFF
--- a/__tests__/actions/mystery-box-history.test.ts
+++ b/__tests__/actions/mystery-box-history.test.ts
@@ -231,8 +231,15 @@ describe("Mystery box history", () => {
 
     expect(boxesPage1?.data.length).toEqual(MYSTERY_BOXES_PER_PAGE);
     expect(boxesPage1?.hasMore).toBeTruthy();
+    boxesPage1.data.map((item) => {
+      expect(["Validation", "Campaign"]).toContain(item.category);
+    });
 
     const boxesPage2 = await fetchMysteryBoxHistory({ currentPage: 2 });
+
+    boxesPage2.data.map((item) => {
+      expect(["Validation", "Campaign"]).toContain(item.category);
+    });
 
     expect(boxesPage2?.data.length).toEqual(2);
     expect(boxesPage2?.hasMore).toBeFalsy();

--- a/__tests__/actions/mystery-box-history.test.ts
+++ b/__tests__/actions/mystery-box-history.test.ts
@@ -181,6 +181,23 @@ describe("Mystery box history", () => {
           }),
         ),
       );
+
+      await prisma.mysteryBoxTrigger.create({
+        data: {
+          triggerType: EBoxTriggerType.ClaimAllCompleted,
+          mysteryBoxId: createdBoxes[0].id,
+          MysteryBoxPrize: {
+            create: {
+              status: EBoxPrizeStatus.Claimed,
+              size: EPrizeSize.Small,
+              prizeType: EBoxPrizeType.Credits,
+              tokenAddress: null,
+              amount: "1000",
+              claimedAt: new Date(),
+            },
+          },
+        },
+      });
     }
 
     await createMysteryBoxTriggers();

--- a/app/actions/mysteryBox/fetchHistory.ts
+++ b/app/actions/mysteryBox/fetchHistory.ts
@@ -25,7 +25,9 @@ export async function fetchMysteryBoxHistory({
       status: EMysteryBoxStatus.Opened,
       triggers: {
         some: {
-          triggerType: {},
+          triggerType: {
+            in: ["ValidationReward", "CampaignReward"],
+          },
           MysteryBoxPrize: {
             some: {}, // Ensures there is at least one MysteryBoxPrize
           },


### PR DESCRIPTION
Description
Update the code in a way that we only show validation and campaign box in history
Reason
Legacy box doesn't have openedAt date causing it to show not opened state. 