### PR TITLE
fix: handle parsedTx for versioned tx

### DIFF
--- a/app/utils/sendBonk.ts
+++ b/app/utils/sendBonk.ts
@@ -156,6 +156,7 @@ export const sendBonk = async (toWallet: PublicKey, amount: number) => {
 
         const result = await CONNECTION.getParsedTransaction(signature, {
           commitment: "confirmed",
+          maxSupportedTransactionVersion: 0,
         });
 
         if (!result || result?.meta?.err) {


### PR DESCRIPTION
This change handle the getParsedTransaction() RPC method for VersionedTransaction. It will throw an error if this argument is not present. The transaction is successful but verification fails due to the missing arg. Fortunately, this issue didn't interrupt the flow in sendBonk as it returns signature. It had just log the error in Sentry.

https://gator-labs.sentry.io/issues/6331582431/events/71e23881da05460880c2f983f73f1b44/

Ref:
https://www.quicknode.com/docs/solana/getParsedTransaction
https://solana.com/developers/guides/advanced/versions#how-to-set-max-supported-version