### PR TITLE
feat: add state to prevent multiple clicks on mystery box open flow

### DIFF
--- a/app/components/MysteryBoxReward/MysteryBoxReward.tsx
+++ b/app/components/MysteryBoxReward/MysteryBoxReward.tsx
@@ -30,16 +30,23 @@ function MysteryBoxReward({
 }) {
   const [showBoxOverlay, setShowBoxOverlay] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 
   const [mystryBoxIds, setMysteryBoxIds] = useState<string[]>([]);
 
-  const { promiseToast } = useToast();
+  const { promiseToast, infoToast } = useToast();
 
   const showTooltip = !!infoBody && !!infoTitle && !isActive;
 
   const rewardBoxHandler = async () => {
     if (!isActive) return;
+    if (isSubmitting) {
+      infoToast("Please wait while we are processing you reward!");
+      return;
+    }
+
     try {
+      setIsSubmitting(true);
       const res = await promiseToast(
         rewardMysteryBoxHub({ type, campaignBoxId }),
         {
@@ -54,6 +61,7 @@ function MysteryBoxReward({
     } catch {
       console.log("Failed to open the Mystery Box. Please try again later. 😔");
     } finally {
+      setIsSubmitting(false);
       setShowBoxOverlay(true);
     }
   };


### PR DESCRIPTION
Process state for open mystery box flow. User won't be able be able to invoke the same action multiple times. 