### PR TITLE
PROD-753: Bulk purchase credits in purchase credits modal

### DIFF
--- a/actions/credits/getPackList.ts
+++ b/actions/credits/getPackList.ts
@@ -1,0 +1,14 @@
+"use server";
+
+import { getJwtPayload } from "@/app/actions/jwt";
+import prisma from "@/app/services/prisma";
+
+export async function getCreditPackList() {
+  const payload = await getJwtPayload();
+  if (!payload) return null;
+
+  return await prisma.creditPack.findMany({
+    orderBy: { amount: "desc" },
+    where: { isActive: true },
+  });
+}

--- a/app/api/cron/process-credits/route.ts
+++ b/app/api/cron/process-credits/route.ts
@@ -37,6 +37,9 @@ export async function GET(request: Request) {
         },
         failedAt: null,
       },
+      include: {
+        creditPack: true,
+      },
     });
 
     // Process transactions

--- a/components/BuyBulkCreditsDrawer.tsx
+++ b/components/BuyBulkCreditsDrawer.tsx
@@ -181,9 +181,9 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
               />
               <div className="relative flex items-center py-2">
                 <hr />
-                <div className="border-gray-600 border-t w-full"></div>
+                <div className="border-gray-500 border-t w-full"></div>
                 <span className="px-6 font-bold text-sm">Or</span>
-                <div className="border-gray-600 border-b w-full h-1/2"></div>
+                <div className="border-gray-500 border-b w-full h-1/2"></div>
               </div>
             </>
           )}

--- a/components/BuyBulkCreditsDrawer.tsx
+++ b/components/BuyBulkCreditsDrawer.tsx
@@ -70,19 +70,35 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
 
   const updateCreditsToBuy = (value: string) => {
     const numValue = Number(value);
+    if (selectedPackId !== null) {
+      setSelectedPack(null);
+      setSelectedPackId(null);
+    }
     if (isNaN(numValue) || numValue < 0 || !Number.isFinite(numValue))
       setCreditsToBuy(undefined);
     else setCreditsToBuy(numValue);
   };
 
   const incrementCreditsToBuy = () => {
-    if (creditsToBuy === undefined) setCreditsToBuy(1);
-    else setCreditsToBuy(creditsToBuy + 1);
+    if (selectedPackId !== null) {
+      setSelectedPack(null);
+      setSelectedPackId(null);
+      setCreditsToBuy(1);
+    } else {
+      if (creditsToBuy === undefined) setCreditsToBuy(1);
+      else setCreditsToBuy(creditsToBuy + 1);
+    }
   };
 
   const decrementCreditsToBuy = () => {
-    if (creditsToBuy === undefined || creditsToBuy === 0) return;
-    setCreditsToBuy(creditsToBuy - 1);
+    if (selectedPackId !== null) {
+      setSelectedPack(null);
+      setSelectedPackId(null);
+      setCreditsToBuy(1);
+    } else {
+      if (creditsToBuy === undefined || creditsToBuy === 0) return;
+      setCreditsToBuy(creditsToBuy - 1);
+    }
   };
 
   const buyCredits = async () => {
@@ -237,13 +253,12 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
               placeholder="0 Credits"
               className="block h-full w-full px-4 py-2 border border-gray-600 rounded-md bg-gray-800 text-white placeholder-gray-400 focus:ring-indigo-500 focus:border-indigo-500"
               value={selectedPackId === null ? creditsToBuy : ""}
-              disabled={selectedPackId !== null || isProcessingTx || isLoading}
+              disabled={isProcessingTx || isLoading}
               onChange={(e) => updateCreditsToBuy(e.target.value)}
             />
             <Button
               className="min-w-[3.5em]"
               disabled={
-                selectedPackId !== null ||
                 creditsToBuy === 0 ||
                 creditsToBuy === undefined ||
                 isProcessingTx ||
@@ -256,8 +271,7 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
             <Button
               className="min-w-[3.5em]"
               disabled={
-                selectedPackId !== null ||
-                hasInsufficientFunds ||
+                (hasInsufficientFunds && selectedPackId === null) ||
                 isProcessingTx ||
                 isLoading
               }

--- a/components/BuyBulkCreditsDrawer.tsx
+++ b/components/BuyBulkCreditsDrawer.tsx
@@ -85,7 +85,10 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
   const buyCredits = async () => {
     setIsLoading(true);
     try {
-      const result = await processCreditPurchase(creditsToBuy ?? 0);
+      const result = await processCreditPurchase(
+        creditsToBuy ?? 0,
+        selectedPack,
+      );
 
       if (result && "error" in result) {
         toast(errorToastLayout(result.error), toastOptions);

--- a/components/BuyBulkCreditsDrawer.tsx
+++ b/components/BuyBulkCreditsDrawer.tsx
@@ -183,7 +183,6 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
                 selected={selectedPackId}
               />
               <div className="relative flex items-center py-2">
-                <hr />
                 <div className="border-gray-500 border-t w-full"></div>
                 <span className="px-6 font-bold text-sm">Or</span>
                 <div className="border-gray-500 border-b w-full h-1/2"></div>

--- a/components/BuyBulkCreditsDrawer.tsx
+++ b/components/BuyBulkCreditsDrawer.tsx
@@ -1,3 +1,4 @@
+import { getCreditPackList } from "@/actions/credits/getPackList";
 import ChompFullScreenLoader from "@/app/components/ChompFullScreenLoader/ChompFullScreenLoader";
 import { CloseIcon } from "@/app/components/Icons/CloseIcon";
 import { Button } from "@/app/components/ui/button";
@@ -12,14 +13,17 @@ import { useCreditPurchase } from "@/hooks/useCreditPurchase";
 import { ChainEnum } from "@dynamic-labs/sdk-api";
 import { useTokenBalances } from "@dynamic-labs/sdk-react-core";
 import { useDynamicContext } from "@dynamic-labs/sdk-react-core";
+import { CreditPack } from "@prisma/client";
 import { DialogTitle } from "@radix-ui/react-dialog";
 import Decimal from "decimal.js";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
-const MAX_CREDITS = 1000;
+import CreditPackList from "./CreditPackList";
+
+const MAX_CREDITS = 100000;
 
 Decimal.set({ toExpNeg: -128 });
 
@@ -29,12 +33,18 @@ type BuyBulkCreditsDrawerProps = {
 };
 
 function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
+  const [packs, setPacks] = useState<CreditPack[]>([]);
+  const [selectedPack, setSelectedPack] = useState<CreditPack | null>(null);
+  const [selectedPackId, setSelectedPackId] = useState<string | null>(null);
+
   const [isLoading, setIsLoading] = useState(false);
   const [creditsToBuy, setCreditsToBuy] = useState<number | undefined>(
     undefined,
   );
   const solPricePerCredit = process.env.NEXT_PUBLIC_SOLANA_COST_PER_CREDIT;
-  const totalSolCost = new Decimal(solPricePerCredit!).mul(creditsToBuy ?? 0);
+  const totalSolCost = new Decimal(
+    selectedPack !== null ? selectedPack.costPerCredit : solPricePerCredit!,
+  ).mul(creditsToBuy ?? 0);
   const router = useRouter();
   const { primaryWallet } = useDynamicContext();
 
@@ -110,6 +120,27 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
     }
   };
 
+  const handleSelectPack = (packId: string | null) => {
+    if (packId !== null) {
+      const newPack = packs.find((pack) => pack.id == packId);
+      if (newPack) {
+        setCreditsToBuy(newPack.amount);
+        setSelectedPack(newPack);
+        setSelectedPackId(newPack.id);
+      }
+    } else {
+      setCreditsToBuy(undefined);
+      setSelectedPack(null);
+      setSelectedPackId(null);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      setPacks((await getCreditPackList()) ?? []);
+    })();
+  }, []);
+
   return (
     <>
       {isProcessingTx && (
@@ -135,10 +166,27 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
               </div>
             </div>
           </DialogTitle>
-          <div className="text-sm font-medium">
-            <p>Buy Credits for {solPricePerCredit} SOL each.</p>
+          <div className="text-sm font-medium mb-2">
+            <p>
+              Select your desired amount of credits and tap on &quot;Buy
+              Credits&quot; to purchase with SOL.
+            </p>
           </div>
-          <hr className="border-gray-600 my-2 p-0" />
+          {packs && packs.length > 0 && (
+            <>
+              <CreditPackList
+                packs={packs}
+                onSelect={handleSelectPack}
+                selected={selectedPackId}
+              />
+              <div className="relative flex items-center py-2">
+                <hr />
+                <div className="border-gray-600 border-t w-full"></div>
+                <span className="px-6 font-bold text-sm">Or</span>
+                <div className="border-gray-600 border-b w-full h-1/2"></div>
+              </div>
+            </>
+          )}
           <div className="grid grid-cols-[1fr_auto_auto] gap-2">
             <input
               id="creditsToBuy"
@@ -149,15 +197,16 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
               min="1"
               max={MAX_CREDITS}
               required
-              placeholder="0"
+              placeholder="0 Credits"
               className="block h-full w-full px-4 py-2 border border-gray-600 rounded-md bg-gray-800 text-white placeholder-gray-400 focus:ring-indigo-500 focus:border-indigo-500"
-              value={creditsToBuy}
-              disabled={isProcessingTx || isLoading}
+              value={selectedPackId === null ? creditsToBuy : ""}
+              disabled={selectedPackId !== null || isProcessingTx || isLoading}
               onChange={(e) => updateCreditsToBuy(e.target.value)}
             />
             <Button
               className="min-w-[3.5em]"
               disabled={
+                selectedPackId !== null ||
                 creditsToBuy === 0 ||
                 creditsToBuy === undefined ||
                 isProcessingTx ||
@@ -169,12 +218,18 @@ function BuyBulkCreditsDrawer({ isOpen, onClose }: BuyBulkCreditsDrawerProps) {
             </Button>
             <Button
               className="min-w-[3.5em]"
-              disabled={hasInsufficientFunds || isProcessingTx || isLoading}
+              disabled={
+                selectedPackId !== null ||
+                hasInsufficientFunds ||
+                isProcessingTx ||
+                isLoading
+              }
               onClick={() => incrementCreditsToBuy()}
             >
               +
             </Button>
           </div>
+          <hr className="border-purple-500 my-2 p-0" />
           <div className="flex flex-col gap-2">
             <span className="flex justify-between my-2 text-sm font-medium">
               <span>Subtotal</span>

--- a/components/CreditPackList.tsx
+++ b/components/CreditPackList.tsx
@@ -1,0 +1,39 @@
+import { CreditPack } from "@prisma/client";
+
+import CreditPackListItem from "./CreditPackListItem";
+
+type CreditPackListProps = {
+  packs: CreditPack[];
+  onSelect: (packId: string | null) => void;
+  selected: string | null;
+};
+
+function CreditPackList({ packs, onSelect, selected }: CreditPackListProps) {
+  const handleToggle = (packId: string) => {
+    if (selected === packId) {
+      if (onSelect) onSelect(null);
+    } else {
+      if (onSelect) onSelect(packId);
+    }
+  };
+
+  return (
+    <>
+      <div className="text-sm font-bold">Limited Time Offer!</div>
+      <ul className="flex flex-col gap-2">
+        {packs.map((pack) => (
+          <CreditPackListItem
+            amount={pack.amount}
+            costPerCredit={pack.costPerCredit}
+            originalCostPerCredit={pack.originalCostPerCredit}
+            onToggle={() => handleToggle(pack.id)}
+            key={pack.id}
+            isSelected={selected == pack.id}
+          />
+        ))}
+      </ul>
+    </>
+  );
+}
+
+export default CreditPackList;

--- a/components/CreditPackListItem.tsx
+++ b/components/CreditPackListItem.tsx
@@ -1,0 +1,60 @@
+import { Button } from "@/app/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type CreditPackListItemProps = {
+  amount: number;
+  costPerCredit: string;
+  originalCostPerCredit: string;
+  onToggle: (isSelected: boolean) => void;
+  isSelected: boolean;
+};
+
+function CreditPackListItem({
+  amount,
+  costPerCredit,
+  originalCostPerCredit,
+  onToggle,
+  isSelected,
+}: CreditPackListItemProps) {
+  const handleSelect = () => {
+    if (onToggle) {
+      onToggle(!isSelected);
+    }
+  };
+
+  return (
+    <li
+      className={cn(
+        "border-2 rounded-md border-dashed flex border-gray-500 p-2 items-center justify-between",
+        { "bg-purple-300": isSelected, "bg-gray-600": !isSelected },
+      )}
+    >
+      {isSelected ? (
+        <div className="text-white font-black py-2 px-2 text-xl">
+          {amount} Credits
+        </div>
+      ) : (
+        <div className="bg-blue-pink-gradient inline-block text-transparent bg-clip-text font-black py-2 px-2 text-xl text-black">
+          {amount} Credits
+        </div>
+      )}
+
+      <div className="flex flex-col text-sm font-bold">
+        {costPerCredit != originalCostPerCredit && (
+          <span className="text-gray-400 line-through">
+            {originalCostPerCredit} SOL
+          </span>
+        )}
+        <span> {costPerCredit} SOL</span>
+      </div>
+
+      <div>
+        <Button onClick={handleSelect} className="px-3">
+          {isSelected ? "Unselect" : "Select"}
+        </Button>
+      </div>
+    </li>
+  );
+}
+
+export default CreditPackListItem;

--- a/components/CreditPackListItem.tsx
+++ b/components/CreditPackListItem.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/app/components/ui/button";
 import { cn } from "@/lib/utils";
+import Decimal from "decimal.js";
 
 type CreditPackListItemProps = {
   amount: number;
@@ -22,6 +23,11 @@ function CreditPackListItem({
     }
   };
 
+  const originalTotal = new Decimal(originalCostPerCredit)
+    .mul(amount)
+    .toString();
+  const newTotal = new Decimal(costPerCredit).mul(amount).toString();
+
   return (
     <li
       className={cn(
@@ -42,10 +48,10 @@ function CreditPackListItem({
       <div className="flex flex-col text-sm font-bold">
         {costPerCredit != originalCostPerCredit && (
           <span className="text-gray-400 line-through">
-            {originalCostPerCredit} SOL
+            {originalTotal} SOL
           </span>
         )}
-        <span> {costPerCredit} SOL</span>
+        <span> {newTotal} SOL</span>
       </div>
 
       <div>

--- a/components/CreditPackListItem.tsx
+++ b/components/CreditPackListItem.tsx
@@ -1,6 +1,5 @@
 import { Button } from "@/app/components/ui/button";
 import { cn } from "@/lib/utils";
-import Decimal from "decimal.js";
 
 type CreditPackListItemProps = {
   amount: number;
@@ -23,11 +22,6 @@ function CreditPackListItem({
     }
   };
 
-  const originalTotal = new Decimal(originalCostPerCredit)
-    .mul(amount)
-    .toString();
-  const newTotal = new Decimal(costPerCredit).mul(amount).toString();
-
   return (
     <li
       className={cn(
@@ -48,10 +42,10 @@ function CreditPackListItem({
       <div className="flex flex-col text-sm font-bold">
         {costPerCredit != originalCostPerCredit && (
           <span className="text-gray-400 line-through">
-            {originalTotal} SOL
+            {originalCostPerCredit} SOL
           </span>
         )}
-        <span> {newTotal} SOL</span>
+        <span> {costPerCredit} SOL</span>
       </div>
 
       <div>

--- a/hooks/useCreditPurchase.ts
+++ b/hooks/useCreditPurchase.ts
@@ -2,13 +2,17 @@ import { initiateCreditPurchase } from "@/actions/credits/initiatePurchase";
 import { createCreditPurchaseTransaction } from "@/lib/credits/createTransaction";
 import { useDynamicContext } from "@dynamic-labs/sdk-react-core";
 import { isSolanaWallet } from "@dynamic-labs/solana";
+import { CreditPack } from "@prisma/client";
 import { useState } from "react";
 
 export function useCreditPurchase() {
   const [isProcessingTx, setIsProcessingTx] = useState(false);
   const { primaryWallet } = useDynamicContext();
 
-  const processCreditPurchase = async (creditsToBuy: number) => {
+  const processCreditPurchase = async (
+    creditsToBuy: number,
+    creditPack: CreditPack | null = null,
+  ) => {
     if (!primaryWallet || !isSolanaWallet(primaryWallet)) {
       return {
         error: "Please connect your Solana wallet",
@@ -20,6 +24,7 @@ export function useCreditPurchase() {
       const data = await createCreditPurchaseTransaction(
         creditsToBuy,
         primaryWallet,
+        creditPack,
       );
 
       if (
@@ -39,6 +44,7 @@ export function useCreditPurchase() {
         creditsToBuy,
         data?.signature,
         data?.transaction,
+        creditPack?.id,
       );
 
       if (result?.error) {

--- a/lib/credits/createChainTx.ts
+++ b/lib/credits/createChainTx.ts
@@ -79,6 +79,7 @@ export async function createSignedSignatureChainTx(
         wallet: wallet?.address,
         recipientAddress: solPaymentAddress,
         type: EChainTxType.CreditPurchase,
+        creditPackId: creditPack?.id,
       },
     });
   } catch (error) {

--- a/lib/credits/getCreditPack.ts
+++ b/lib/credits/getCreditPack.ts
@@ -1,0 +1,12 @@
+"server-only";
+
+import prisma from "@/app/services/prisma";
+
+export async function getCreditPack(packId: string) {
+  return await prisma.creditPack.findUniqueOrThrow({
+    where: {
+      id: packId,
+      isActive: true,
+    },
+  });
+}

--- a/lib/credits/updateTxStatusConfirm.ts
+++ b/lib/credits/updateTxStatusConfirm.ts
@@ -21,6 +21,7 @@ const MAX_RETRIES = 3;
 export async function updateTxStatusToConfirmed(
   hash: string,
   creditAmount: number,
+  creditPackId: string | undefined = undefined,
 ) {
   const payload = await getJwtPayload();
 
@@ -49,6 +50,7 @@ export async function updateTxStatusToConfirmed(
               asset: FungibleAsset.Credit,
               change: creditAmount,
               type: TransactionLogType.CreditPurchase,
+              creditPackId: creditPackId ?? null,
               userId,
             },
           });

--- a/prisma/migrations/20250305234145_add_credit_packs/migration.sql
+++ b/prisma/migrations/20250305234145_add_credit_packs/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable
+ALTER TABLE "FungibleAssetTransactionLog" ADD COLUMN     "creditPackId" TEXT;
+
+-- CreateTable
+CREATE TABLE "CreditPack" (
+    "id" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "costPerCredit" TEXT NOT NULL,
+    "originalCostPerCredit" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "CreditPack_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "FungibleAssetTransactionLog" ADD CONSTRAINT "FungibleAssetTransactionLog_creditPackId_fkey" FOREIGN KEY ("creditPackId") REFERENCES "CreditPack"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20250306200809_add_creditpack_to_chaintx/migration.sql
+++ b/prisma/migrations/20250306200809_add_creditpack_to_chaintx/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "ChainTx" ADD COLUMN     "creditPackId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "ChainTx" ADD CONSTRAINT "ChainTx_creditPackId_fkey" FOREIGN KEY ("creditPackId") REFERENCES "CreditPack"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -324,6 +324,8 @@ model ChainTx {
   failedAt                    DateTime?
   FungibleAssetTransactionLog FungibleAssetTransactionLog[]
   MysteryBoxPrize             MysteryBoxPrize[]
+  creditPack                  CreditPack?                   @relation(fields: [creditPackId], references: [id])
+  creditPackId                String?
 
   @@index([hash])
 }
@@ -358,6 +360,7 @@ model CreditPack {
   originalCostPerCredit String
   isActive              Boolean
   fungibleAssetTransactionLog FungibleAssetTransactionLog[]
+  chainTx               ChainTx[]
   createdAt             DateTime @default(now())
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -207,6 +207,8 @@ model FungibleAssetTransactionLog {
   mysteryBoxPrizeId String?            @unique
   chainTx           ChainTx?           @relation(fields: [chainTxHash], references: [hash])
   chainTxHash       String?
+  creditPack        CreditPack?        @relation(fields: [creditPackId], references: [id])
+  creditPackId      String?
 
   @@unique([type, userId, questionId]) // Enforce unique combination of userId and questionId
   @@unique([type, deckId, userId]) // Enforce unique combination of deckId and userId
@@ -347,6 +349,16 @@ model CampaignMysteryBoxAllowlist {
   mysteryBoxAllowList MysteryBoxAllowlist @relation(fields: [address], references: [address])
 
   @@unique([campaignMysteryBoxId, address])
+}
+
+model CreditPack {
+  id                    String @id @default(uuid())
+  amount                Int
+  costPerCredit         String
+  originalCostPerCredit String
+  isActive              Boolean
+  fungibleAssetTransactionLog FungibleAssetTransactionLog[]
+  createdAt             DateTime @default(now())
 }
 
 enum EMysteryBoxStatus {


### PR DESCRIPTION
This implements the credit pack options in the bulk buy modal.

Credit packs are stored in the database. They store the current credit cost as well as the discounted rate, so can be referenced in the FATL to see historical prices (if the credit cost ever changes). That does mean the existing records should be immutable though (a possible weakness of this design... easy to forget). The current prisma schema uses UUIDs for the packs, but this could be changed to a descriptive const-style string.

Unfortunately. I had to duplicate the `creditPack` reference in `ChainTx` as the process-credits cronjob needs it to recover any failed transactions. It's not ideal, but keeping the pack info only in `ChainTx` also doesn't feel right. I'm open to alternative ideas.

The credits logic is a bit complicated, so here is a reminder of the flow:

- Drawer component:
  - [FE] processCreditPurchase()
    - [FE] createCreditPurchaseTransaction()
    - [SERVER ACTION] initiateCreditPurchase()
      - [BE] createSignedSignatureChainTx()
      - [BE] processTransaction()
        - [BE] verifyPayment()
        - [BE] updateTxStatusToConfirmed()

![creditpacks](https://github.com/user-attachments/assets/cb4c0165-cfb6-451e-8854-0f9ca7f3a3d4)