### PR TITLE
PROD-884: Store signature in send bonk

### DIFF
--- a/app/actions/mysteryBox/openMysteryBoxHub.ts
+++ b/app/actions/mysteryBox/openMysteryBoxHub.ts
@@ -7,7 +7,6 @@ import {
   EBoxPrizeStatus,
   EBoxPrizeType,
   EChainTxStatus,
-  EChainTxType,
   EMysteryBoxStatus,
   FungibleAsset,
   TransactionLogType,
@@ -120,7 +119,6 @@ export const openMysteryBoxHub = async (mysteryBoxIds: string[]) => {
     0,
   );
 
-  const bonkAddress = process.env.NEXT_PUBLIC_BONK_ADDRESS || "";
   let txHash: string | null = null;
   try {
     if (totalBonkAmount > 0) {
@@ -142,17 +140,13 @@ export const openMysteryBoxHub = async (mysteryBoxIds: string[]) => {
             throw new Error("Treasury address not defined");
           }
 
-          await tx.chainTx.create({
+          await tx.chainTx.update({
             data: {
-              hash: txHash,
-              wallet: treasury,
-              recipientAddress: userWallet.address,
-              type: EChainTxType.MysteryBoxClaim,
               status: EChainTxStatus.Finalized,
-              solAmount: "0",
-              tokenAmount: totalBonkAmount.toString(),
-              tokenAddress: bonkAddress,
               finalizedAt: date,
+            },
+            where: {
+              hash: txHash,
             },
           });
         }


### PR DESCRIPTION
We store signature in credit payment even if it fails, this PR add similar update in claim MB. It will create ChainTx even before confirming tx. Later, update the status in client.