### PR TITLE
chore: temporarily remove process-credits cron job pending permanent fix

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,10 +10,6 @@
       "schedule": "0 * * * *"
     },
     {
-      "path": "/api/cron/process-credits",
-      "schedule": "*/1 * * * *"
-    },
-    {
       "path": "/api/cron/calculate-correct-answers",
       "schedule": "* * * * *"
     },


### PR DESCRIPTION
Disabling the cron job as a temporary measure until a permanent 
solution can be implemented. This prevents the failed transaction from getting confirmed. 
