### PR TITLE
PROD-912: Add "per credit" label for credit pack price.

### DIFF
--- a/components/CreditPackListItem.tsx
+++ b/components/CreditPackListItem.tsx
@@ -41,11 +41,24 @@ function CreditPackListItem({
 
       <div className="flex flex-col text-sm font-bold">
         {costPerCredit != originalCostPerCredit && (
-          <span className="text-gray-400 line-through">
+          <span
+            className={cn("line-through", {
+              "text-gray-400": !isSelected,
+              "text-gray-200": isSelected,
+            })}
+          >
             {originalCostPerCredit} SOL
           </span>
         )}
         <span> {costPerCredit} SOL</span>
+        <span
+          className={cn("text-xs", {
+            "text-gray-400": !isSelected,
+            "text-gray-200": isSelected,
+          })}
+        >
+          per credit
+        </span>
       </div>
 
       <div>


### PR DESCRIPTION
Add "per credit" label for credit pack price.

Also make greyed out text more visible when selected.

![percredit](https://github.com/user-attachments/assets/4f2e15df-6894-40b4-9aac-b5b209134707)
