### PR TITLE
PROD-901: Display 2nd order average based on selected responses

### DIFF
--- a/actions/answers/answerQuestion.ts
+++ b/actions/answers/answerQuestion.ts
@@ -16,7 +16,6 @@ import {
 } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";
 import { revalidatePath } from "next/cache";
-import { release } from "os";
 
 export type SaveQuestionRequest = {
   questionId: number;
@@ -191,7 +190,6 @@ export async function answerQuestion(request: SaveQuestionRequest) {
     );
     Sentry.captureException(answerError);
     await Sentry.flush(SENTRY_FLUSH_WAIT);
-    release();
     throw error;
   }
 }

--- a/app/queries/answerPercentageQuery.ts
+++ b/app/queries/answerPercentageQuery.ts
@@ -41,7 +41,7 @@ export async function answerPercentageQuery(questionOptionIds: number[]) {
                   select round(avg(percentage))
                   from public."QuestionAnswer"
                   join public."User" u on "userId" = u."id"
-                  where "questionOptionId" = qo."id" and "status" = 'Submitted' and (u."threatLevel" IS NULL OR u."threatLevel" IN (${EThreatLevelType.ManualAllow}, ${EThreatLevelType.PermanentAllow}))
+                  where "questionOptionId" = qo."id" and "selected" is true AND "status" = 'Submitted' and (u."threatLevel" IS NULL OR u."threatLevel" IN (${EThreatLevelType.ManualAllow}, ${EThreatLevelType.PermanentAllow}))
                 ) as "secondOrderAveragePercentagePicked"
               from public."QuestionOption" qo
               where qo."id" in (${Prisma.join(questionOptionIds)})


### PR DESCRIPTION
Resolves an issue with calculated second order percentages by limiting denominator to selected answers rather than entire cohort.

The problem is these incorrect results are stored in the database and used elsewhere; I have created follow-up tickets to look into this.