### PR TITLE
feat: update mystery box openedAt history date to display in utc

### DIFF
--- a/components/MysteryBoxHub/MysteryBoxHistoryCard.tsx
+++ b/components/MysteryBoxHub/MysteryBoxHistoryCard.tsx
@@ -34,10 +34,13 @@ function MysteryBoxHistoryCard({ box }: MysteryBoxHistoryCardProps) {
               <div className="text-right">Opened on</div>
               <div className="text-right">
                 <b>
-                  {openDate?.toLocaleString("en-US", { month: "short" })}{" "}
-                  {openDate?.getDate()}
+                  {new Date(openDate)?.toLocaleString("en-US", {
+                    month: "short",
+                    timeZone: "UTC",
+                  })}{" "}
+                  {openDate?.getUTCDate()}
                 </b>{" "}
-                {openDate.getFullYear()}
+                {openDate?.getUTCFullYear()}
               </div>
             </>
           ) : (


### PR DESCRIPTION
Description: Display mystery box history date in utc. 

Testing: Try update the mystery box prize openedAt date in a way that in your timezone it should be a day before as compared to your time zone. But it should still show the day before date. 