### PR TITLE
PROD-914: Don't query backend if parameters are unavailable

### DIFF
--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -49,6 +49,9 @@ const NotAvailableYet = ({ msg }: { msg: string }) => {
 };
 
 const RevealAnswerPage = async ({ params }: Props) => {
+  // Parameters can be undefined on the first render;
+  // return a promise to trigger suspense further up
+  // the tree until we have the values.
   if (params.questionId === undefined)
     throw new Promise((r) => setTimeout(r, 0));
 

--- a/app/application/answer/reveal/[questionId]/page.tsx
+++ b/app/application/answer/reveal/[questionId]/page.tsx
@@ -49,6 +49,9 @@ const NotAvailableYet = ({ msg }: { msg: string }) => {
 };
 
 const RevealAnswerPage = async ({ params }: Props) => {
+  if (params.questionId === undefined)
+    throw new Promise((r) => setTimeout(r, 0));
+
   const [questionResponse, user] = await Promise.all([
     getQuestionWithUserAnswer(Number(params.questionId)),
     getCurrentUser(),


### PR DESCRIPTION
During the first render of the page, the URL parameters are (sometimes) unavailable, which means we send a request to the backend with an undefined question ID, triggering a Prisma error.

Returning a promise triggers suspense (i.e. the Chompy loading screen) further up the tree. There is a better solution to this problem, but we'd need NextJS 15.x.