### PR TITLE
fix: give bot detector more buffer after replica

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
     },
     {
       "path": "/api/cron/detect-bot-activity",
-      "schedule": "50 * * * *"
+      "schedule": "58 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Run bot detector 8 minutes later so there is less of a chance of conflicting with the replica job. https://gator-labs.slack.com/archives/C06054PPNSY/p1742808063639379