### PR TITLE
PROD-963: Make credit cost an input field rather than select box.

### DIFF
--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -567,7 +567,7 @@ export default function DeckForm({
             variant="secondary"
             type="number"
             min="0"
-            pattern="/^[0-9]$/"
+            pattern="/^[0-9]+$/"
             className="text-gray-800 w-full"
             {...register("creditCostPerQuestion", {
               setValueAs: (v) => (!v ? 0 : parseInt(v)),

--- a/app/components/DeckForm/DeckForm.tsx
+++ b/app/components/DeckForm/DeckForm.tsx
@@ -563,7 +563,11 @@ export default function DeckForm({
       {CREDIT_COST_FEATURE_FLAG && (
         <div className="mb-3">
           <label className="block mb-1">Credit cost per question</label>
-          <select
+          <TextInput
+            variant="secondary"
+            type="number"
+            min="0"
+            pattern="/^[0-9]$/"
             className="text-gray-800 w-full"
             {...register("creditCostPerQuestion", {
               setValueAs: (v) => (!v ? 0 : parseInt(v)),
@@ -575,13 +579,10 @@ export default function DeckForm({
                   );
               },
             })}
-          >
-            {Array.from({ length: 6 }, (_, i) => i).map((i) => (
-              <option value={i} key={i}>
-                {i}
-              </option>
-            ))}
-          </select>
+          />
+          <div className="text-destructive">
+            {errors.creditCostPerQuestion?.message}
+          </div>
         </div>
       )}
       <div className="mb-4">

--- a/app/schemas/deck.ts
+++ b/app/schemas/deck.ts
@@ -114,7 +114,7 @@ export const deckSchema = z
     revealTokenAmount: z.number().min(0),
     revealAtDate: z.date({ message: "Reveal at date is required" }),
     revealAtAnswerCount: z.number().min(0).nullish(),
-    creditCostPerQuestion: z.number().min(0).max(5).nullish(),
+    creditCostPerQuestion: z.number().min(0),
     questions: z
       .object({
         id: z.number().optional(),

--- a/app/schemas/deck.ts
+++ b/app/schemas/deck.ts
@@ -114,7 +114,7 @@ export const deckSchema = z
     revealTokenAmount: z.number().min(0),
     revealAtDate: z.date({ message: "Reveal at date is required" }),
     revealAtAnswerCount: z.number().min(0).nullish(),
-    creditCostPerQuestion: z.number().min(0),
+    creditCostPerQuestion: z.number().min(0).nullish(),
     questions: z
       .object({
         id: z.number().optional(),


### PR DESCRIPTION
Make the credit cost control in the admin dashboard an input field so any amount can be entered.