### PR TITLE
fix: increase max body size server actions

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -30,8 +30,9 @@ const nextConfig = {
   swcMinify: true,
   experimental: {
     missingSuspenseWithCSRBailout: false,
+    // https://nextjs.org/docs/14/app/api-reference/next-config-js/serverActions#bodysizelimit
     serverActions: {
-      bodySizeLimit: "3mb",
+      bodySizeLimit: "30mb",
     },
     serverComponentsExternalPackages: ["@aws-sdk"],
   },


### PR DESCRIPTION
Error seems to be due to body size limit. Increased significantly to test this theory. Can only easily be tested in the wild by real users. 

https://nextjs.org/docs/14/app/api-reference/next-config-js/serverActions#bodysizelimit