### PR TITLE
PROD-956: Add INDEX to QuestionAnswer table.

### DIFF
--- a/prisma/migrations/20250328143906_add_questionanswer_index/migration.sql
+++ b/prisma/migrations/20250328143906_add_questionanswer_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "QuestionAnswer_userId_selected_idx" ON "QuestionAnswer"("userId", "selected");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,6 +168,7 @@ model QuestionAnswer {
   updatedAt        DateTime       @default(now()) @updatedAt
 
   @@unique([questionOptionId, userId], name: "question_option_user")
+  @@index([userId, selected])
 }
 
 model ChompResult {


### PR DESCRIPTION
This adds an index to the QuestionAnswer table. I already added the index to the prod database for testing (I will remove it so Prisma recreates it when I do the release).