### PR TITLE
PROD-965: Ability to assign a submitted question to a community deck

### DIFF
--- a/__tests__/lib/ask/addToCommunityAskList.test.ts
+++ b/__tests__/lib/ask/addToCommunityAskList.test.ts
@@ -6,8 +6,18 @@ describe("Add to community ask list", () => {
   let question1: { id: number };
   let question2: { id: number };
   let deck: { id: number };
+  let origCommunityStack: { id: number } | null;
+  let origCommunityDeck: { id: number } | null;
 
   beforeAll(async () => {
+    origCommunityStack = await prisma.stack.findUnique({
+      where: { specialId: ESpecialStack.CommunityAsk },
+    });
+
+    origCommunityDeck = await prisma.stack.findUnique({
+      where: { specialId: ESpecialStack.CommunityAsk },
+    });
+
     // TODO: make a user-submitted question (with
     // appropriate flag)
     question1 = await prisma.question.create({
@@ -76,6 +86,16 @@ describe("Add to community ask list", () => {
       where: { id: { in: [question1.id, question2.id] } },
     });
     await prisma.deck.delete({ where: { id: deck.id } });
+
+    if (!origCommunityDeck)
+      await prisma.deck.deleteMany({
+        where: { stack: { specialId: ESpecialStack.CommunityAsk } },
+      });
+
+    if (!origCommunityStack)
+      await prisma.stack.delete({
+        where: { specialId: ESpecialStack.CommunityAsk },
+      });
   });
 
   it("should add a community question to list", async () => {

--- a/__tests__/lib/ask/addToCommunityAskList.test.ts
+++ b/__tests__/lib/ask/addToCommunityAskList.test.ts
@@ -18,14 +18,13 @@ describe("Add to community ask list", () => {
       where: { specialId: ESpecialStack.CommunityAsk },
     });
 
-    // TODO: make a user-submitted question (with
-    // appropriate flag)
     question1 = await prisma.question.create({
       data: {
         stackId: null,
         question: "User question",
         type: "BinaryQuestion",
         revealTokenAmount: 10,
+        isSubmittedByUser: true,
         questionOptions: {
           create: [
             {
@@ -56,6 +55,7 @@ describe("Add to community ask list", () => {
         question: "Non-user question",
         type: "BinaryQuestion",
         revealTokenAmount: 10,
+        isSubmittedByUser: false,
         questionOptions: {
           create: [
             {

--- a/__tests__/lib/ask/addToCommunityAskList.test.ts
+++ b/__tests__/lib/ask/addToCommunityAskList.test.ts
@@ -1,0 +1,113 @@
+import prisma from "@/app/services/prisma";
+import { addToCommunityDeck } from "@/lib/ask/addToCommunityDeck";
+import { ESpecialStack } from "@prisma/client";
+
+describe("Add to community ask list", () => {
+  let question1: { id: number };
+  let question2: { id: number };
+  let deck: { id: number };
+
+  beforeAll(async () => {
+    // TODO: make a user-submitted question (with
+    // appropriate flag)
+    question1 = await prisma.question.create({
+      data: {
+        stackId: null,
+        question: "User question",
+        type: "BinaryQuestion",
+        revealTokenAmount: 10,
+        questionOptions: {
+          create: [
+            {
+              option: "Cats",
+            },
+            {
+              option: "Dogs",
+            },
+          ],
+        },
+      },
+    });
+
+    deck = await prisma.deck.create({
+      data: {
+        deck: "Deck Sample",
+        revealAtDate: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        stackId: null,
+      },
+      include: {
+        deckQuestions: true,
+      },
+    });
+
+    question2 = await prisma.question.create({
+      data: {
+        stackId: null,
+        question: "Non-user question",
+        type: "BinaryQuestion",
+        revealTokenAmount: 10,
+        questionOptions: {
+          create: [
+            {
+              option: "Fauna",
+            },
+            {
+              option: "Flora",
+            },
+          ],
+        },
+        deckQuestions: {
+          create: {
+            deckId: deck.id,
+          },
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.deckQuestion.deleteMany({
+      where: { questionId: { in: [question1.id, question2.id] } },
+    });
+    await prisma.questionOption.deleteMany({
+      where: { questionId: { in: [question1.id, question2.id] } },
+    });
+    await prisma.question.deleteMany({
+      where: { id: { in: [question1.id, question2.id] } },
+    });
+    await prisma.deck.delete({ where: { id: deck.id } });
+  });
+
+  it("should add a community question to list", async () => {
+    await addToCommunityDeck(question1.id);
+
+    const communityStack = await prisma.stack.findUnique({
+      where: { specialId: ESpecialStack.CommunityAsk },
+    });
+
+    expect(communityStack).toBeDefined();
+
+    const lastCommunityDeck = await prisma.deck.findFirst({
+      where: {
+        stackId: communityStack!.id,
+        OR: [{ activeFromDate: null }, { activeFromDate: { gt: new Date() } }],
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    expect(lastCommunityDeck).toBeDefined();
+
+    const q1 = await prisma.question.findUnique({
+      where: { id: question1.id },
+      include: { deckQuestions: true },
+    });
+
+    expect(q1?.deckQuestions?.[0]?.deckId).toEqual(lastCommunityDeck!.id);
+  });
+
+  it("should not add an arbitrary question to list", async () => {
+    await expect(addToCommunityDeck(question2.id)).rejects.toThrow();
+  });
+});

--- a/lib/ask/addToCommunityDeck.ts
+++ b/lib/ask/addToCommunityDeck.ts
@@ -44,7 +44,15 @@ export async function addToCommunityDeck(questionId: number): Promise<void> {
     }
 
     // Ensure the question exists
-    await tx.question.findFirstOrThrow({ where: { id: questionId } });
+    // TODO: update to ensure this is a community question
+    await tx.question.findFirstOrThrow({
+      where: {
+        id: questionId,
+        deckQuestions: {
+          none: {},
+        },
+      },
+    });
 
     await tx.deckQuestion.create({
       data: {

--- a/lib/ask/addToCommunityDeck.ts
+++ b/lib/ask/addToCommunityDeck.ts
@@ -6,18 +6,18 @@ import { ESpecialStack } from "@prisma/client";
 export async function addToCommunityDeck(questionId: number): Promise<void> {
   let stack = await prisma.stack.findUnique({
     where: {
-      specialId: ESpecialStack.CommunityAsk
-    }
+      specialId: ESpecialStack.CommunityAsk,
+    },
   });
 
   if (!stack) {
     stack = await prisma.stack.create({
       data: {
-        name: 'Community Stack',
+        name: "Community Stack",
         specialId: ESpecialStack.CommunityAsk,
         isActive: false,
-        image: '',
-      }
+        image: "",
+      },
     });
   }
 
@@ -26,21 +26,18 @@ export async function addToCommunityDeck(questionId: number): Promise<void> {
   let deck = await prisma.deck.findFirst({
     where: {
       stackId: stack.id,
-      OR: [
-        { activeFromDate: null },
-        { activeFromDate: { gt: now } },
-      ]
+      OR: [{ activeFromDate: null }, { activeFromDate: { gt: now } }],
     },
     orderBy: {
-      'createdAt': 'desc'
-    }
+      createdAt: "desc",
+    },
   });
 
   if (!deck) {
     deck = await prisma.deck.create({
       data: {
         stackId: stack.id,
-        deck: 'Community Deck',
+        deck: "Community Deck",
       },
     });
   }
@@ -53,7 +50,7 @@ export async function addToCommunityDeck(questionId: number): Promise<void> {
       data: {
         questionId,
         deckId: deck.id,
-      }
+      },
     });
 
     // Sync values from the parent deck
@@ -62,9 +59,10 @@ export async function addToCommunityDeck(questionId: number): Promise<void> {
         creditCostPerQuestion: deck.creditCostPerQuestion,
         revealAtDate: deck.revealAtDate,
         revealAtAnswerCount: deck.revealAtAnswerCount,
-      }, where: {
-        id: questionId
-      }
+      },
+      where: {
+        id: questionId,
+      },
     });
   });
 }

--- a/lib/ask/addToCommunityDeck.ts
+++ b/lib/ask/addToCommunityDeck.ts
@@ -44,10 +44,10 @@ export async function addToCommunityDeck(questionId: number): Promise<void> {
     }
 
     // Ensure the question exists
-    // TODO: update to ensure this is a community question
     await tx.question.findFirstOrThrow({
       where: {
         id: questionId,
+        isSubmittedByUser: true,
         deckQuestions: {
           none: {},
         },

--- a/prisma/migrations/20250330205841_add_specialid_column_to_stack/migration.sql
+++ b/prisma/migrations/20250330205841_add_specialid_column_to_stack/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[specialId]` on the table `Stack` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateEnum
+CREATE TYPE "ESpecialStack" AS ENUM ('CommunityAsk');
+
+-- AlterTable
+ALTER TABLE "Stack" ADD COLUMN     "specialId" "ESpecialStack";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Stack_specialId_key" ON "Stack"("specialId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -233,15 +233,18 @@ model RevealNft {
 }
 
 model Stack {
-  id                   Int        @id @default(autoincrement())
+  id                   Int            @id @default(autoincrement())
+  specialId            ESpecialStack? // Identifies special stacks, e.g. community stack
   name                 String
   isActive             Boolean
-  isVisible            Boolean    @default(true)
-  hideDeckFromHomepage Boolean    @default(false)
+  isVisible            Boolean        @default(true)
+  hideDeckFromHomepage Boolean        @default(false)
   image                String
   questions            Question[]
-  createdAt            DateTime   @default(now())
+  createdAt            DateTime       @default(now())
   deck                 Deck[]
+
+  @@unique(specialId)
 }
 
 model Banner {
@@ -359,14 +362,18 @@ model CampaignMysteryBoxAllowlist {
 }
 
 model CreditPack {
-  id                    String @id @default(uuid())
-  amount                Int
-  costPerCredit         String
-  originalCostPerCredit String
-  isActive              Boolean
+  id                          String                        @id @default(uuid())
+  amount                      Int
+  costPerCredit               String
+  originalCostPerCredit       String
+  isActive                    Boolean
   fungibleAssetTransactionLog FungibleAssetTransactionLog[]
-  chainTx               ChainTx[]
-  createdAt             DateTime @default(now())
+  chainTx                     ChainTx[]
+  createdAt                   DateTime                      @default(now())
+}
+
+enum ESpecialStack {
+  CommunityAsk
 }
 
 enum EMysteryBoxStatus {


### PR DESCRIPTION
Implement assignment to community deck feature.

Some of the complexity from the ticket wasn't needed in the end:

- We can easily identify the draft deck as it belongs to the community stack (since it is added there immediately after creation).
- The `addedToDeckAt` field is available as `DeckQuestion.createdAt`.

I have added a `specialId` field which gives us a way to identify special decks such as the community ask deck; we have the flexibility to add others in the future.