### PR TITLE
PROD-984: Don't move from profile form if profile update failed.

### DIFF
--- a/app/components/ProfileForm/ProfileForm.tsx
+++ b/app/components/ProfileForm/ProfileForm.tsx
@@ -80,6 +80,7 @@ export function ProfileForm({ profile }: ProfileFormProps) {
 
     if (!!res?.error) {
       errorToast(res?.error);
+      return;
     }
     router.push("/application");
     successToast("Profile successfully updated");


### PR DESCRIPTION
If an existing username is entered, we currently show both success and error toasts and redirect back to the homepage.