### PR TITLE
Fix: community ask stacks page

### DIFF
--- a/app/components/Stack/Stack.tsx
+++ b/app/components/Stack/Stack.tsx
@@ -12,7 +12,7 @@ import StacksHeader from "../StacksHeader/StacksHeader";
 type StackProps = {
   stack: ExtendedStack;
   totalNumberOfCards: number;
-  blurData: GetPlaiceholderReturn;
+  blurData?: GetPlaiceholderReturn;
   userId: string | undefined;
 };
 
@@ -29,8 +29,8 @@ export const Stack = ({
         <div className="relative w-[100.5px] h-[100.5px]">
           <Image
             src={stack.image}
-            blurDataURL={blurData?.base64}
-            placeholder="blur"
+            blurDataURL={blurData?.base64 ?? ""}
+            placeholder={blurData?.base64 ? "blur" : "empty"}
             fill
             alt={stack.name}
             className="object-cover"

--- a/app/components/StackForm/StackForm.tsx
+++ b/app/components/StackForm/StackForm.tsx
@@ -67,8 +67,13 @@ export default function StackForm({ stack, action }: StackFormProps) {
         }
       })}
     >
-      <h1 className="text-3xl mb-3">
+      <h1 className="text-3xl mb-3 flex align-items: center">
         {stack ? `Edit stack #${stack.id}` : "Create stack"}
+        {stack?.specialId && (
+          <span className="bg-purple-600 rounded-md p-2 ml-4 text-sm font-bold">
+            Special: {stack?.specialId}
+          </span>
+        )}
       </h1>
       <div className="mb-3">
         <label className="block mb-1">Stack</label>

--- a/app/stacks/[id]/page.tsx
+++ b/app/stacks/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getStack } from "@/app/queries/stack";
 import { getCurrentUser } from "@/app/queries/user";
 import { getBlurData } from "@/app/utils/getBlurData";
 import { getTotalNumberOfDeckQuestions } from "@/app/utils/question";
+import { ESpecialStack } from "@prisma/client";
 import { notFound } from "next/navigation";
 
 type PageProps = {
@@ -14,6 +15,11 @@ type PageProps = {
 const StackPage = async ({ params: { id } }: PageProps) => {
   const [stack, user] = await Promise.all([getStack(+id), getCurrentUser()]);
 
+  const FF_ASK = process.env.NEXT_PUBLIC_FF_ASK === "true";
+
+  if (!FF_ASK && stack?.specialId == ESpecialStack.CommunityAsk)
+    return notFound();
+
   if (!stack || (stack.isActive === false && stack?.isVisible === false))
     return notFound();
 
@@ -21,7 +27,7 @@ const StackPage = async ({ params: { id } }: PageProps) => {
 
   const totalNumberOfCards = getTotalNumberOfDeckQuestions(deckQuestions);
 
-  const blurData = await getBlurData(stack.image);
+  const blurData = stack.image ? await getBlurData(stack.image) : undefined;
 
   return (
     <Stack

--- a/lib/ask/addToCommunityDeck.ts
+++ b/lib/ask/addToCommunityDeck.ts
@@ -16,6 +16,7 @@ export async function addToCommunityDeck(questionId: number): Promise<void> {
         name: "Community Stack",
         specialId: ESpecialStack.CommunityAsk,
         isActive: false,
+        isVisible: false,
         image: "",
       },
     });


### PR DESCRIPTION
Fixes:

- Don't die if there is no stack image (currently the case for the auto-created community stack)
- Don't show the community ask stack info page if the ask feature flag is unset.
- Set community stack to invisible initially.
- Add a badge in the admin panel for special stacks.