### PR TITLE
feat: add new history header

### DIFF
--- a/__tests__/queries/history/get-decks-history.test.ts
+++ b/__tests__/queries/history/get-decks-history.test.ts
@@ -14,7 +14,7 @@ jest.mock("@/app/utils/auth", () => ({
 
 jest.mock("p-retry", () => jest.fn().mockImplementation((fn) => fn()));
 
-describe("getAnsweredDecksForHistory", () => {
+describe("getDecksForHistory", () => {
   let userId: string;
   let deck1Id: number;
   let deck2Id: number;
@@ -301,12 +301,10 @@ describe("getAnsweredDecksForHistory", () => {
     const result = await getDecksForHistory(userId, 10, 1);
     console.log(result);
 
-    // Should return only deck1 and deck2 (revealed decks with answers)
-    expect(result).toHaveLength(3);
-
     const deckIds = result.map((deck) => deck.id);
     expect(deckIds).toContain(deck1Id);
     expect(deckIds).toContain(deck2Id);
+    expect(deckIds).toContain(deck4Id);
     expect(deckIds).not.toContain(deck3Id); // Future date, should not be included
   });
 

--- a/__tests__/queries/history/get-decks-history.test.ts
+++ b/__tests__/queries/history/get-decks-history.test.ts
@@ -1,0 +1,362 @@
+import { getDecksForHistory } from "@/app/queries/history";
+import prisma from "@/app/services/prisma";
+import { generateUsers } from "@/scripts/utils";
+import {
+  AnswerStatus,
+  QuestionOption,
+  QuestionType,
+  Token,
+} from "@prisma/client";
+
+jest.mock("@/app/utils/auth", () => ({
+  authGuard: jest.fn(),
+}));
+
+jest.mock("p-retry", () => jest.fn().mockImplementation((fn) => fn()));
+
+describe("getAnsweredDecksForHistory", () => {
+  let userId: string;
+  let deck1Id: number;
+  let deck2Id: number;
+  let deck3Id: number;
+  let deck4Id: number;
+  let question1Id: number;
+  let question2Id: number;
+  let question3Id: number;
+  let question4Id: number;
+  let questionOptions: QuestionOption[] = [];
+  let deckQuestionIds: number[] = [];
+
+  const pastDate = new Date();
+  pastDate.setDate(pastDate.getDate() - 2); // 2 days ago
+
+  const futureDate = new Date();
+  futureDate.setDate(futureDate.getDate() + 2); // 2 days in the future
+
+  beforeAll(async () => {
+    const user = await generateUsers(1);
+    userId = user[0].id;
+
+    // Create test user
+    await prisma.user.create({
+      data: {
+        id: userId,
+      },
+    });
+
+    // Create test decks
+    const [deck1, deck2, deck3, deck4] = await Promise.all([
+      // Deck 1: Revealed (past date), with rewards (credit cost > 0)
+      prisma.deck.create({
+        data: {
+          deck: "Premium Deck",
+          revealAtDate: pastDate,
+          creditCostPerQuestion: 2,
+        },
+      }),
+      // Deck 2: Revealed (past date), no rewards (credit cost = 0)
+      prisma.deck.create({
+        data: {
+          deck: "Free Deck",
+          revealAtDate: pastDate,
+          creditCostPerQuestion: 0,
+        },
+      }),
+      // Deck 3: Not revealed (future date), with rewards
+      prisma.deck.create({
+        data: {
+          deck: "Unrevealed Premium Deck",
+          revealAtDate: futureDate,
+          creditCostPerQuestion: 5,
+        },
+      }),
+      // Deck 4: Revealed (past date), with rewards, but no answered questions
+      prisma.deck.create({
+        data: {
+          deck: "Premium Deck No Answers",
+          revealAtDate: pastDate,
+          creditCostPerQuestion: 2,
+        },
+      }),
+    ]);
+
+    deck1Id = deck1.id;
+    deck2Id = deck2.id;
+    deck3Id = deck3.id;
+    deck4Id = deck4.id;
+
+    // Create test questions
+    const [question1, question2, question3, question4] = await Promise.all([
+      // Question 1: For deck 1, with credit cost
+      prisma.question.create({
+        data: {
+          question: "What is the capital of France?",
+          type: QuestionType.BinaryQuestion,
+          durationMiliseconds: 60000,
+          revealToken: Token.Bonk,
+          revealTokenAmount: 100,
+          creditCostPerQuestion: 2,
+          revealAtDate: pastDate,
+        },
+      }),
+      // Question 2: For deck 2, no credit cost
+      prisma.question.create({
+        data: {
+          question: "What is the capital of UK?",
+          type: QuestionType.BinaryQuestion,
+          durationMiliseconds: 60000,
+          revealToken: Token.Bonk,
+          revealTokenAmount: 0,
+          creditCostPerQuestion: 0,
+          revealAtDate: pastDate,
+        },
+      }),
+      // Question 3: For deck 3, with credit cost
+      prisma.question.create({
+        data: {
+          question: "What is the capital of Germany?",
+          type: QuestionType.BinaryQuestion,
+          durationMiliseconds: 60000,
+          revealToken: Token.Bonk,
+          revealTokenAmount: 100,
+          creditCostPerQuestion: 5,
+          revealAtDate: futureDate,
+        },
+      }),
+      // Question 4: For deck 4, with credit cost
+      prisma.question.create({
+        data: {
+          question: "What is the capital of Italy?",
+          type: QuestionType.BinaryQuestion,
+          durationMiliseconds: 60000,
+          revealToken: Token.Bonk,
+          revealTokenAmount: 100,
+          creditCostPerQuestion: 2,
+          revealAtDate: pastDate,
+        },
+      }),
+    ]);
+
+    question1Id = question1.id;
+    question2Id = question2.id;
+    question3Id = question3.id;
+    question4Id = question4.id;
+
+    // Create question options for all questions
+    const optionsData = [];
+    for (const questionId of [
+      question1Id,
+      question2Id,
+      question3Id,
+      question4Id,
+    ]) {
+      optionsData.push(
+        {
+          option: "Option A",
+          isCorrect: true,
+          isLeft: true,
+          questionId,
+        },
+        {
+          option: "Option B",
+          isCorrect: false,
+          isLeft: false,
+          questionId,
+        },
+      );
+    }
+
+    await prisma.questionOption.createMany({
+      data: optionsData,
+    });
+
+    // Fetch created options
+    questionOptions = await prisma.questionOption.findMany({
+      where: {
+        questionId: {
+          in: [question1Id, question2Id, question3Id, question4Id],
+        },
+      },
+    });
+
+    // Link questions to decks
+    const deckQuestions = await Promise.all([
+      prisma.deckQuestion.create({
+        data: {
+          deckId: deck1Id,
+          questionId: question1Id,
+        },
+      }),
+      prisma.deckQuestion.create({
+        data: {
+          deckId: deck2Id,
+          questionId: question2Id,
+        },
+      }),
+      prisma.deckQuestion.create({
+        data: {
+          deckId: deck3Id,
+          questionId: question3Id,
+        },
+      }),
+      prisma.deckQuestion.create({
+        data: {
+          deckId: deck4Id,
+          questionId: question4Id,
+        },
+      }),
+    ]);
+
+    deckQuestionIds = deckQuestions.map((dq) => dq.id);
+
+    // Create answers for questions 1, 2, and 3 (not 4)
+    const question1Options = questionOptions.filter(
+      (opt) => opt.questionId === question1Id,
+    );
+    const question2Options = questionOptions.filter(
+      (opt) => opt.questionId === question2Id,
+    );
+
+    await Promise.all([
+      // Answer for question 1
+      prisma.questionAnswer.create({
+        data: {
+          userId,
+          questionOptionId: question1Options[0].id,
+          selected: true,
+          status: AnswerStatus.Submitted,
+        },
+      }),
+      // Answer for question 2
+      prisma.questionAnswer.create({
+        data: {
+          userId,
+          questionOptionId: question2Options[0].id,
+          selected: true,
+          status: AnswerStatus.Submitted,
+        },
+      }),
+      // Answer for question 3
+      // prisma.questionAnswer.create({
+      //   data: {
+      //     userId,
+      //     questionOptionId: question3Options[0].id,
+      //     selected: true,
+      //     status: AnswerStatus.Submitted,
+      //   },
+      // }),
+    ]);
+  });
+
+  afterAll(async () => {
+    // Clean up in reverse order
+
+    await prisma.questionAnswer.deleteMany({
+      where: {
+        userId,
+        questionOptionId: {
+          in: questionOptions.map((opt) => opt.id),
+        },
+      },
+    });
+
+    await prisma.deckQuestion.deleteMany({
+      where: {
+        id: {
+          in: deckQuestionIds,
+        },
+      },
+    });
+
+    await prisma.questionOption.deleteMany({
+      where: {
+        questionId: {
+          in: [question1Id, question2Id, question3Id, question4Id],
+        },
+      },
+    });
+
+    await prisma.question.deleteMany({
+      where: {
+        id: {
+          in: [question1Id, question2Id, question3Id, question4Id],
+        },
+      },
+    });
+
+    await prisma.deck.deleteMany({
+      where: {
+        id: {
+          in: [deck1Id, deck2Id, deck3Id, deck4Id],
+        },
+      },
+    });
+
+    await prisma.user.delete({
+      where: { id: userId },
+    });
+  });
+
+  it("should return both answered and unanswered deck", async () => {
+    const result = await getDecksForHistory(userId, 10, 1);
+    console.log(result);
+
+    // Should return only deck1 and deck2 (revealed decks with answers)
+    expect(result).toHaveLength(3);
+
+    const deckIds = result.map((deck) => deck.id);
+    expect(deckIds).toContain(deck1Id);
+    expect(deckIds).toContain(deck2Id);
+    expect(deckIds).not.toContain(deck3Id); // Future date, should not be included
+  });
+
+  it("should correctly calculate total_reward_amount and total_credit_cost", async () => {
+    const result = await getDecksForHistory(userId, 10, 1);
+
+    // Find deck1 in results (the one with rewards)
+    const deck1Result = result.find((deck) => deck.id === deck1Id);
+    expect(deck1Result).toBeDefined();
+
+    expect(Number(deck1Result?.total_reward_amount)).toBe(0);
+
+    expect(Number(deck1Result?.total_potential_reward_amount)).toBe(100);
+    expect(Number(deck1Result?.total_credit_cost)).toBe(2);
+
+    // Find deck2 in results (the one without rewards)
+    const deck2Result = result.find((deck) => deck.id === deck2Id);
+    expect(deck2Result).toBeDefined();
+    expect(Number(deck2Result?.total_potential_reward_amount)).toBe(0);
+    expect(Number(deck2Result?.total_reward_amount)).toBe(0);
+    expect(Number(deck2Result?.total_credit_cost)).toBe(0);
+  });
+
+  it("should respect pagination parameters", async () => {
+    // Test with page size 1, page 1
+    const page1Result = await getDecksForHistory(userId, 1, 1);
+    expect(page1Result).toHaveLength(1);
+
+    // Test with page size 1, page 2
+    const page2Result = await getDecksForHistory(userId, 1, 2);
+    expect(page2Result).toHaveLength(1);
+
+    // Ensure page 1 and page 2 return different decks
+    expect(page1Result[0].id).not.toBe(page2Result[0].id);
+  });
+
+  it("should return the correct deck properties", async () => {
+    const result = await getDecksForHistory(userId, 10, 1);
+
+    // Check that all required properties are present
+    const deck = result.find((d) => d.id === deck1Id);
+    expect(deck).toHaveProperty("id");
+    expect(deck).toHaveProperty("deck");
+    expect(deck).toHaveProperty("revealAtDate");
+    expect(deck).toHaveProperty("total_reward_amount");
+    expect(deck).toHaveProperty("total_credit_cost");
+    expect(deck).toHaveProperty("answeredQuestions");
+    expect(deck).toHaveProperty("totalQuestions");
+
+    // Check specific values
+    expect(deck?.deck).toBe("Premium Deck");
+  });
+});

--- a/__tests__/queries/history/getAnsweredDecksForHistory.test.ts
+++ b/__tests__/queries/history/getAnsweredDecksForHistory.test.ts
@@ -342,7 +342,9 @@ describe("getAnsweredDecksForHistory", () => {
     // Find deck1 in results (the one with rewards)
     const deck1Result = result.find((deck) => deck.id === deck1Id);
     expect(deck1Result).toBeDefined();
-    expect(deck1Result?.total_reward_amount).toBe(null);
+
+    expect(Number(deck1Result?.total_reward_amount)).toBe(0);
+
     expect(Number(deck1Result?.total_potential_reward_amount)).toBe(100);
     expect(Number(deck1Result?.total_credit_cost)).toBe(2);
 
@@ -462,6 +464,8 @@ describe("getAnsweredDecksForHistory", () => {
     expect(deck).toHaveProperty("revealAtDate");
     expect(deck).toHaveProperty("total_reward_amount");
     expect(deck).toHaveProperty("total_credit_cost");
+    expect(deck).toHaveProperty("answeredQuestions");
+    expect(deck).toHaveProperty("totalQuestions");
 
     // Check specific values
     expect(deck?.deck).toBe("Premium Deck");

--- a/__tests__/queries/home/deck.test.ts
+++ b/__tests__/queries/home/deck.test.ts
@@ -49,19 +49,22 @@ describe("queryExpiringDecks", () => {
     const tomorrow = new Date(now);
     tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
 
+    const yestarday = new Date(now);
+    yestarday.setUTCDate(yestarday.getUTCDate() - 1);
+
     // Create decks
     const deckData = [
       {
         data: {
           deck: "Deck 1",
-          activeFromDate: now,
+          activeFromDate: yestarday,
           revealAtDate: tomorrow,
         },
       },
       {
         data: {
           deck: "Deck 2",
-          activeFromDate: now,
+          activeFromDate: yestarday,
           revealAtDate: tomorrow,
         },
       },

--- a/app/actions/history.ts
+++ b/app/actions/history.ts
@@ -8,6 +8,7 @@ import {
   NewQuestionHistoryData,
   QuestionHistory,
   getAnsweredDecksForHistory,
+  getDecksForHistory,
   getHistoryHeadersData,
   getNewHistoryQuery,
   getQuestionsHistoryQuery,
@@ -19,8 +20,10 @@ const PAGE_SIZE = 10;
 
 export const getHistoryDecks = async ({
   pageParam,
+  showAnsweredDeck,
 }: {
   pageParam: number;
+  showAnsweredDeck: boolean;
 }): Promise<DeckHistoryItem[]> => {
   const payload = await getJwtPayload();
 
@@ -28,7 +31,15 @@ export const getHistoryDecks = async ({
     return [];
   }
 
-  return getAnsweredDecksForHistory(payload.sub, HISTORY_DECK_LIMIT, pageParam);
+  if (showAnsweredDeck) {
+    return getAnsweredDecksForHistory(
+      payload.sub,
+      HISTORY_DECK_LIMIT,
+      pageParam,
+    );
+  } else {
+    return getDecksForHistory(payload.sub, HISTORY_DECK_LIMIT, pageParam);
+  }
 };
 
 export const getQuestionsHistory = async ({

--- a/app/actions/history.ts
+++ b/app/actions/history.ts
@@ -1,14 +1,9 @@
 "use server";
 
-import { DeckHistoryItem } from "@/types/history";
-
-import { HISTORY_DECK_LIMIT } from "../constants/decks";
 import {
   NewQuestionHistory,
   NewQuestionHistoryData,
   QuestionHistory,
-  getAnsweredDecksForHistory,
-  getDecksForHistory,
   getHistoryHeadersData,
   getNewHistoryQuery,
   getQuestionsHistoryQuery,
@@ -17,30 +12,6 @@ import prisma from "../services/prisma";
 import { getJwtPayload } from "./jwt";
 
 const PAGE_SIZE = 10;
-
-export const getHistoryDecks = async ({
-  pageParam,
-  showAnsweredDeck,
-}: {
-  pageParam: number;
-  showAnsweredDeck: boolean;
-}): Promise<DeckHistoryItem[]> => {
-  const payload = await getJwtPayload();
-
-  if (!payload?.sub) {
-    return [];
-  }
-
-  if (showAnsweredDeck) {
-    return getAnsweredDecksForHistory(
-      payload.sub,
-      HISTORY_DECK_LIMIT,
-      pageParam,
-    );
-  } else {
-    return getDecksForHistory(payload.sub, HISTORY_DECK_LIMIT, pageParam);
-  }
-};
 
 export const getQuestionsHistory = async ({
   pageParam,

--- a/app/api/history/deck/route.ts
+++ b/app/api/history/deck/route.ts
@@ -1,0 +1,45 @@
+import { getJwtPayload } from "@/app/actions/jwt";
+import { getHistoryDecks } from "@/lib/history/deck";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+
+const schema = z.object({
+  pageParam: z.string().transform((val) => parseInt(val, 10)), // Convert to number
+  showAnsweredDeck: z.string().transform((val) => val === "true"), // Convert to boolean
+});
+
+export async function GET(request: NextRequest) {
+  const payload = await getJwtPayload();
+
+  const userId = payload?.sub;
+
+  let req;
+
+  try {
+    const searchParams = request.nextUrl.searchParams;
+    const params = Object.fromEntries(searchParams.entries());
+
+    req = schema.parse(params);
+  } catch {
+    return new Response(JSON.stringify({ error: "Invalid request" }), {
+      status: 500,
+    });
+  }
+
+  const pageParam = req.pageParam;
+  const showAnsweredDeck = req.showAnsweredDeck;
+
+  const history = await getHistoryDecks({
+    userId,
+    pageParam,
+    showAnsweredDeck,
+  });
+  return new Response(
+    JSON.stringify({
+      history,
+    }),
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+}

--- a/app/application/history/page.tsx
+++ b/app/application/history/page.tsx
@@ -1,6 +1,7 @@
 import { getTotalClaimableRewards } from "@/app/actions/history";
 import History from "@/app/components/History/History";
 import HistoryHeader from "@/app/components/HistoryHeader/HistoryHeader";
+import NewHistoryHeader from "@/app/components/NewHistoryHeader/NewHistoryHeader";
 import ProfileNavigation from "@/app/components/ProfileNavigation/ProfileNavigation";
 import { getAllQuestionsReadyForReveal } from "@/app/queries/history";
 import { getProfileImage } from "@/app/queries/profile";
@@ -24,10 +25,7 @@ export default async function Page() {
 
         {FF_CREDITS ? (
           <>
-            <h1 className="font-bold py-2 px-2 text-2xl">History</h1>
-
-            <hr className="border-gray-600 my-0 p-0" />
-
+            <NewHistoryHeader />
             <HistoryList />
           </>
         ) : (

--- a/app/application/history/page.tsx
+++ b/app/application/history/page.tsx
@@ -1,7 +1,6 @@
 import { getTotalClaimableRewards } from "@/app/actions/history";
 import History from "@/app/components/History/History";
 import HistoryHeader from "@/app/components/HistoryHeader/HistoryHeader";
-import NewHistoryHeader from "@/app/components/NewHistoryHeader/NewHistoryHeader";
 import ProfileNavigation from "@/app/components/ProfileNavigation/ProfileNavigation";
 import { getAllQuestionsReadyForReveal } from "@/app/queries/history";
 import { getProfileImage } from "@/app/queries/profile";
@@ -25,7 +24,6 @@ export default async function Page() {
 
         {FF_CREDITS ? (
           <>
-            <NewHistoryHeader />
             <HistoryList />
           </>
         ) : (

--- a/app/components/HomeFeedDeckCard/HomeFeedDeckCard.tsx
+++ b/app/components/HomeFeedDeckCard/HomeFeedDeckCard.tsx
@@ -3,15 +3,13 @@
 import { TRACKING_EVENTS, TRACKING_METADATA } from "@/app/constants/tracking";
 import { getTimeUntilReveal } from "@/app/utils/history";
 import { formatNumber } from "@/app/utils/number";
+import DeckWrapper from "@/components/Deck/DeckWrapper";
 import trackEvent from "@/lib/trackEvent";
 import { ANSWER_PATH, getDeckPath } from "@/lib/urls";
 import classNames from "classnames";
 import { TrophyIcon } from "lucide-react";
-import Image from "next/image";
 
-import { DeckGraphic } from "../Graphics/DeckGraphic";
 import { ArrowRightCircle } from "../Icons/ArrowRightCircle";
-import CardsIcon from "../Icons/CardsIcon";
 import { CoinsIcon } from "../Icons/CoinsIcon";
 import TrophyQuestionMarkIcon from "../Icons/TrophyQuestionMarkIcon";
 import { RevealCardInfo } from "../RevealCardInfo/RevealCardInfo";
@@ -87,8 +85,8 @@ export function HomeFeedDeckCard({
       ? (answeredQuestions / totalQuestions) * 100
       : 0;
   return (
-    <a
-      href={date ? ANSWER_PATH : getDeckPath(deckId)}
+    <DeckWrapper
+      linkPath={date ? ANSWER_PATH : getDeckPath(deckId)}
       onClick={() => {
         trackEvent(TRACKING_EVENTS.DECK_CLICKED, {
           [TRACKING_METADATA.DECK_ID]: deckId,
@@ -96,35 +94,12 @@ export function HomeFeedDeckCard({
           [TRACKING_METADATA.IS_DAILY_DECK]: date ? true : false,
         });
       }}
-      className="bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 cursor-pointer h-full"
+      wrapperType="a"
+      answeredQuestions={answeredQuestions}
+      progressPercentage={progressPercentage}
+      imageUrl={imageUrl}
+      deckTitle={deck}
     >
-      <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center relative">
-        {!(answeredQuestions === totalQuestions) && (
-          <div
-            className="absolute top-0 left-0 h-full bg-green opacity-35 z-0 rounded-l-2xl"
-            style={{ width: `${progressPercentage}%` }}
-          ></div>
-        )}
-        <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">
-          {imageUrl ? (
-            <>
-              <CardsIcon className="absolute top-0 left-0 w-full h-full" />
-              <Image
-                src={imageUrl}
-                alt="logo"
-                width={36}
-                height={36}
-                className="z-10 absolute w-8 h-8 rounded-full top-1/2 left-1/2 translate-x-[-50%] -translate-y-1/2 object-cover"
-              />
-            </>
-          ) : (
-            <DeckGraphic className="w-full h-full" />
-          )}
-        </div>
-        <div className="text-white font-semibold text-base line-clamp-2 z-10">
-          {deck}
-        </div>
-      </div>
       <div className="flex items-center justify-between">
         {CREDIT_COST_FEATURE_FLAG && deckCreditCost != null ? (
           deckCreditCost === 0 ? (
@@ -168,6 +143,6 @@ export function HomeFeedDeckCard({
           {status && getStatusText(status, revealAtDate, answeredQuestions)}
         </div>
       </div>
-    </a>
+    </DeckWrapper>
   );
 }

--- a/app/components/NewHistoryHeader/NewHistoryHeader.tsx
+++ b/app/components/NewHistoryHeader/NewHistoryHeader.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { useState } from "react";
+
+import { InfoIcon } from "../Icons/InfoIcon";
+import InfoDrawer from "../InfoDrawer/InfoDrawer";
+
+function NewHistoryHeader() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <InfoDrawer
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="History"
+      >
+        <div className="text-sm mb-6 space-y-6">
+          Browse all revealed decks here. Use the toggle above to filter decks
+          you’ve answered (marked with purple cards).
+        </div>
+      </InfoDrawer>
+      <div className="flex items-center gap-2">
+        <label className="cursor-pointer">
+          <input type="checkbox" className="sr-only peer" />
+          <div className="relative w-11 h-6 bg-gray-600 rounded-full peer-checked:bg-purple-200 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border after:rounded-full after:h-5 after:w-5 after:transition-all"></div>
+        </label>
+        <p className="text-sm">Only decks I&rsquo;ve answered.</p>
+      </div>
+
+      <div className="flex flex-row justify-between items-center">
+        <h1 className="font-bold py-2 px-2 text-lg">History</h1>
+        <button onClick={() => setIsOpen(true)}>
+          <InfoIcon width={18} height={18} fill="#999999" />
+        </button>
+      </div>
+    </>
+  );
+}
+
+export default NewHistoryHeader;

--- a/app/components/NewHistoryHeader/NewHistoryHeader.tsx
+++ b/app/components/NewHistoryHeader/NewHistoryHeader.tsx
@@ -5,7 +5,13 @@ import React, { useState } from "react";
 import { InfoIcon } from "../Icons/InfoIcon";
 import InfoDrawer from "../InfoDrawer/InfoDrawer";
 
-function NewHistoryHeader() {
+function NewHistoryHeader({
+  handleToggleChange,
+  showAnsweredDeck,
+}: {
+  handleToggleChange: () => void;
+  showAnsweredDeck: boolean;
+}) {
   const [isOpen, setIsOpen] = useState(false);
   return (
     <>
@@ -21,7 +27,12 @@ function NewHistoryHeader() {
       </InfoDrawer>
       <div className="flex items-center gap-2">
         <label className="cursor-pointer">
-          <input type="checkbox" className="sr-only peer" />
+          <input
+            type="checkbox"
+            className="sr-only peer"
+            checked={showAnsweredDeck}
+            onChange={handleToggleChange}
+          />
           <div className="relative w-11 h-6 bg-gray-600 rounded-full peer-checked:bg-purple-200 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border after:rounded-full after:h-5 after:w-5 after:transition-all"></div>
         </label>
         <p className="text-sm">Only decks I&rsquo;ve answered.</p>

--- a/app/components/StackDeckCard/StackDeckCard.tsx
+++ b/app/components/StackDeckCard/StackDeckCard.tsx
@@ -2,15 +2,13 @@
 
 import { getTimeUntilReveal } from "@/app/utils/history";
 import { formatNumber } from "@/app/utils/number";
+import DeckWrapper from "@/components/Deck/DeckWrapper";
 import { getDeckPath } from "@/lib/urls";
 import { cn } from "@/lib/utils";
 import { Clock3Icon, TrophyIcon } from "lucide-react";
-import Image from "next/image";
 import { useState } from "react";
 
-import { DeckGraphic } from "../Graphics/DeckGraphic";
 import { ArrowRightCircle } from "../Icons/ArrowRightCircle";
-import CardsIcon from "../Icons/CardsIcon";
 import { CoinsIcon } from "../Icons/CoinsIcon";
 import TrophyQuestionMarkIcon from "../Icons/TrophyQuestionMarkIcon";
 import TrophyStarMarkIcon from "../Icons/TrophyStarMarkIcon";
@@ -96,8 +94,6 @@ const StackDeckCard = ({
 
   const linkPath = getDeckPath(deckId);
 
-  const Wrapper = !!userId ? "a" : "div";
-
   return (
     <>
       <LoginPopUp
@@ -106,43 +102,18 @@ const StackDeckCard = ({
         onClose={() => setIsLoginModalOpen(false)}
         userId={userId}
       />
-      <Wrapper
+      <DeckWrapper
+        linkPath={linkPath}
         onClick={() => {
           if (!userId) setIsLoginModalOpen(true);
         }}
-        href={linkPath}
-        className="bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer"
+        wrapperType={!!userId ? "a" : "div"}
+        answeredQuestions={answeredQuestions}
+        progressPercentage={progressPercentage}
+        imageUrl={imageUrl}
+        deckTitle={deckName}
+        totalQuestions={totalQuestions}
       >
-        <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center relative">
-          {!(answeredQuestions === totalQuestions) && !isDeckReadyToReveal && (
-            <div
-              className="absolute top-0 left-0 h-full bg-green opacity-35 z-0 rounded-l-2xl"
-              style={{ width: `${progressPercentage}%` }}
-            ></div>
-          )}
-          <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">
-            {imageUrl ? (
-              <>
-                <CardsIcon className="absolute top-0 left-0 w-full h-full" />
-                <Image
-                  src={imageUrl}
-                  alt="logo"
-                  width={36}
-                  height={36}
-                  className="z-10 absolute w-8 h-8 rounded-full top-1/2 left-1/2 translate-x-[-50%] -translate-y-1/2 object-cover"
-                  onError={(e) => {
-                    e.currentTarget.src = "/images/chompy.png";
-                  }}
-                />
-              </>
-            ) : (
-              <DeckGraphic className="w-full h-full" />
-            )}
-          </div>
-          <div className="text-white font-semibold text-base line-clamp-2 z-10">
-            {deckName}
-          </div>
-        </div>
         <div className="flex items-center justify-between">
           {deckCreditCost === 0 ? (
             <div className="flex items-center gap-2">
@@ -216,7 +187,7 @@ const StackDeckCard = ({
             {getButtonText(revealAtDate, answeredQuestions, totalQuestions)}
           </div>
         </div>
-      </Wrapper>
+      </DeckWrapper>
     </>
   );
 };

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -389,12 +389,16 @@ export async function getAnsweredDecksForHistory(
        JOIN public."Question" q 
        ON dq."questionId" = q.id
        WHERE dq."deckId" = d.id), 0) AS "total_credit_cost",
-      (SELECT count(*) FROM public."DeckQuestion" dq
+      (SELECT COUNT(DISTINCT q."id") FROM public."DeckQuestion" dq
         JOIN public."Question" q ON dq."questionId" = q.id
         JOIN public."QuestionOption" qo ON qo."questionId" = q.id
         JOIN public."QuestionAnswer" qa ON qa."questionOptionId" = qo.id
         WHERE dq."deckId" = d.id
-        AND qa."userId" = ${userId}) AS "answerCount"
+        AND qa."userId" = ${userId}) AS "answeredQuestions",
+        (SELECT COUNT(DISTINCT dq."questionId")
+     FROM public."DeckQuestion" dq
+     WHERE dq."deckId" = d."id"
+    ) as "totalQuestions"
     FROM 
       public."Deck" d
       LEFT JOIN "DeckRewards" dr ON dr."userId" = ${userId} AND dr."deckId" = d.id
@@ -454,12 +458,16 @@ export async function getDecksForHistory(
        JOIN public."Question" q 
        ON dq."questionId" = q.id
        WHERE dq."deckId" = d.id), 0) AS "total_credit_cost",
-       (SELECT count(*) FROM public."DeckQuestion" dq
+       (SELECT COUNT(DISTINCT q."id") FROM public."DeckQuestion" dq
         JOIN public."Question" q ON dq."questionId" = q.id
         JOIN public."QuestionOption" qo ON qo."questionId" = q.id
         JOIN public."QuestionAnswer" qa ON qa."questionOptionId" = qo.id
         WHERE dq."deckId" = d.id
-        AND qa."userId" = ${userId}) AS "answerCount"
+        AND qa."userId" = ${userId}) AS "answeredQuestions",
+         (SELECT COUNT(DISTINCT dq."questionId")
+     FROM public."DeckQuestion" dq
+     WHERE dq."deckId" = d."id"
+    ) as "totalQuestions"
     FROM 
       public."Deck" d
       LEFT JOIN "DeckRewards" dr ON dr."userId" = ${userId} AND dr."deckId" = d.id

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -415,7 +415,7 @@ export async function getAnsweredDecksForHistory(
         AND qa."userId" = ${userId}
       )
     GROUP BY 
-      d.id, d.deck, d."imageUrl", d."revealAtDate"  -- Removed dr.bonkReward
+      d.id, d.deck, d."imageUrl", d."revealAtDate"  
   ),
   total_count AS (
     SELECT COUNT(*) AS count FROM history_deck_cte
@@ -488,7 +488,7 @@ export async function getDecksForHistory(
     history_deck_cte, total_count
   ORDER BY 
     history_deck_cte."revealAtDate" DESC,
-    history_deck_cte.id DESC
+    history_deck_cte.id DESC -- Added secondary sort
   LIMIT ${pageSize} OFFSET ${offset}
   `;
 

--- a/components/Deck/DeckWrapper.tsx
+++ b/components/Deck/DeckWrapper.tsx
@@ -1,0 +1,115 @@
+import { DeckGraphic } from "@/app/components/Graphics/DeckGraphic";
+import CardsIcon from "@/app/components/Icons/CardsIcon";
+import { cn } from "@/lib/utils";
+import Image from "next/image";
+import React, { ReactNode } from "react";
+
+interface DeckWrapperProps {
+  wrapperType: "a" | "div";
+  linkPath?: string;
+  onClick?: () => void;
+  children: ReactNode;
+  answeredQuestions: number | undefined;
+  imageUrl?: string | null;
+  totalQuestions?: number;
+  deckTitle: string;
+  progressPercentage: number;
+}
+
+const DeckWrapper: React.FC<DeckWrapperProps> = ({
+  wrapperType,
+  linkPath,
+  onClick,
+  children,
+  answeredQuestions,
+  imageUrl,
+  totalQuestions,
+  progressPercentage,
+  deckTitle,
+}) => {
+  return wrapperType === "a" ? (
+    <a
+      onClick={onClick}
+      href={linkPath}
+      className={cn(
+        "bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer",
+        {
+          "bg-chomp-indigo-dark": answeredQuestions && answeredQuestions > 0,
+        },
+      )}
+    >
+      <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center relative">
+        {!(answeredQuestions === totalQuestions) && (
+          <div
+            className="absolute top-0 left-0 h-full bg-green opacity-35 z-0 rounded-l-2xl"
+            style={{ width: `${progressPercentage}%` }}
+          ></div>
+        )}
+        <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">
+          {imageUrl ? (
+            <>
+              <CardsIcon className="absolute top-0 left-0 w-full h-full" />
+              <Image
+                src={imageUrl}
+                alt="logo"
+                width={36}
+                height={36}
+                className="z-10 absolute w-8 h-8 rounded-full top-1/2 left-1/2 translate-x-[-50%] -translate-y-1/2 object-cover"
+                onError={(e) => {
+                  e.currentTarget.src = "/images/chompy.png";
+                }}
+              />
+            </>
+          ) : (
+            <DeckGraphic className="w-full h-full" />
+          )}
+        </div>
+        <div className="text-white font-semibold text-base line-clamp-2 z-10">
+          {deckTitle}
+        </div>
+      </div>
+      {children}
+    </a>
+  ) : (
+    <div
+      onClick={onClick}
+      className={cn(
+        "bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer",
+        {
+          "bg-chomp-indigo-dark": answeredQuestions && answeredQuestions > 0,
+        },
+      )}
+    >
+      <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center relative">
+        {!(answeredQuestions === totalQuestions) && (
+          <div
+            className="absolute top-0 left-0 h-full bg-green opacity-35 z-0 rounded-l-2xl"
+            style={{ width: `${progressPercentage}%` }}
+          ></div>
+        )}
+        <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">
+          {imageUrl ? (
+            <>
+              <CardsIcon className="absolute top-0 left-0 w-full h-full" />
+              <Image
+                src={imageUrl}
+                alt="logo"
+                width={36}
+                height={36}
+                className="z-10 absolute w-8 h-8 rounded-full top-1/2 left-1/2 translate-x-[-50%] -translate-y-1/2 object-cover"
+              />
+            </>
+          ) : (
+            <DeckGraphic className="w-full h-full" />
+          )}
+        </div>
+        <div className="text-white font-semibold text-base line-clamp-2 z-10">
+          {deckTitle}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default DeckWrapper;

--- a/components/HistoryNew/HistoryDeckCard.tsx
+++ b/components/HistoryNew/HistoryDeckCard.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import { DeckGraphic } from "@/app/components/Graphics/DeckGraphic";
 import { ArrowRightCircle } from "@/app/components/Icons/ArrowRightCircle";
-import CardsIcon from "@/app/components/Icons/CardsIcon";
 import TrophyStarMarkIcon from "@/app/components/Icons/TrophyStarMarkIcon";
 import { formatCompactAmount } from "@/app/utils/number";
-import { cn } from "@/app/utils/tailwind";
 import { getDeckPath } from "@/lib/urls";
 import { DeckHistoryItem } from "@/types/history";
 import { TrophyIcon } from "lucide-react";
-import Image from "next/image";
+
+import DeckWrapper from "../Deck/DeckWrapper";
 
 interface HistoryDeckCardProps {
   deck: DeckHistoryItem;
@@ -38,45 +36,15 @@ export const HistoryDeckCard = ({ deck }: HistoryDeckCardProps) => {
       : 0;
 
   return (
-    <a
-      href={linkPath}
-      className={cn(
-        "bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer",
-        {
-          "bg-chomp-indigo-dark": answeredQuestions && answeredQuestions > 0,
-        },
-      )}
+    <DeckWrapper
+      linkPath={linkPath}
+      wrapperType="a"
+      answeredQuestions={answeredQuestions}
+      progressPercentage={progressPercentage}
+      imageUrl={imageUrl}
+      deckTitle={deckName}
+      totalQuestions={totalQuestions}
     >
-      <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center relative">
-        {!(answeredQuestions === totalQuestions) && (
-          <div
-            className="absolute top-0 left-0 h-full bg-green opacity-35 z-0 rounded-l-2xl"
-            style={{ width: `${progressPercentage}%` }}
-          ></div>
-        )}
-        <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">
-          {imageUrl ? (
-            <>
-              <CardsIcon className="absolute top-0 left-0 w-full h-full" />
-              <Image
-                src={imageUrl}
-                alt="logo"
-                width={36}
-                height={36}
-                className="z-10 absolute w-8 h-8 rounded-full top-1/2 left-1/2 translate-x-[-50%] -translate-y-1/2 object-cover"
-                onError={(e) => {
-                  e.currentTarget.src = "/images/chompy.png";
-                }}
-              />
-            </>
-          ) : (
-            <DeckGraphic className="w-full h-full" />
-          )}
-        </div>
-        <div className="text-white font-semibold text-base line-clamp-2 z-10">
-          {deckName}
-        </div>
-      </div>
       <div className="flex items-center justify-between">
         {total_credit_cost === 0 ? (
           <div className="flex bg-[#6C633A] justify-center items-center rounded-xl p-3 gap-1 font-medium text-xs text-white">
@@ -102,6 +70,6 @@ export const HistoryDeckCard = ({ deck }: HistoryDeckCardProps) => {
           </div>
         </div>
       </div>
-    </a>
+    </DeckWrapper>
   );
 };

--- a/components/HistoryNew/HistoryDeckCard.tsx
+++ b/components/HistoryNew/HistoryDeckCard.tsx
@@ -5,6 +5,7 @@ import { ArrowRightCircle } from "@/app/components/Icons/ArrowRightCircle";
 import CardsIcon from "@/app/components/Icons/CardsIcon";
 import TrophyStarMarkIcon from "@/app/components/Icons/TrophyStarMarkIcon";
 import { formatCompactAmount } from "@/app/utils/number";
+import { cn } from "@/app/utils/tailwind";
 import { getDeckPath } from "@/lib/urls";
 import { DeckHistoryItem } from "@/types/history";
 import { TrophyIcon } from "lucide-react";
@@ -22,17 +23,23 @@ export const HistoryDeckCard = ({ deck }: HistoryDeckCardProps) => {
     revealAtDate,
     total_reward_amount,
     total_credit_cost,
+    answerCount,
   } = deck;
 
   const currentDate = new Date();
   const isDeckRevealed = currentDate > revealAtDate;
 
   const linkPath = getDeckPath(id);
-
+  console.log(answerCount, deck);
   return (
     <a
       href={linkPath}
-      className="bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer"
+      className={cn(
+        "bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer",
+        {
+          "bg-chomp-indigo-dark": answerCount && answerCount > 0,
+        },
+      )}
     >
       <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center">
         <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">

--- a/components/HistoryNew/HistoryDeckCard.tsx
+++ b/components/HistoryNew/HistoryDeckCard.tsx
@@ -23,7 +23,8 @@ export const HistoryDeckCard = ({ deck }: HistoryDeckCardProps) => {
     revealAtDate,
     total_reward_amount,
     total_credit_cost,
-    answerCount,
+    answeredQuestions,
+    totalQuestions,
   } = deck;
 
   const currentDate = new Date();
@@ -31,17 +32,28 @@ export const HistoryDeckCard = ({ deck }: HistoryDeckCardProps) => {
 
   const linkPath = getDeckPath(id);
 
+  const progressPercentage =
+    totalQuestions && answeredQuestions
+      ? (answeredQuestions / totalQuestions) * 100
+      : 0;
+
   return (
     <a
       href={linkPath}
       className={cn(
         "bg-gray-700 rounded-2xl p-2 flex flex-col gap-2 h-full cursor-pointer",
         {
-          "bg-chomp-indigo-dark": answerCount && answerCount > 0,
+          "bg-chomp-indigo-dark": answeredQuestions && answeredQuestions > 0,
         },
       )}
     >
-      <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center">
+      <div className="flex bg-gray-800 p-2 rounded-2xl gap-2 items-center relative">
+        {!(answeredQuestions === totalQuestions) && (
+          <div
+            className="absolute top-0 left-0 h-full bg-green opacity-35 z-0 rounded-l-2xl"
+            style={{ width: `${progressPercentage}%` }}
+          ></div>
+        )}
         <div className="w-[59px] h-[60px] bg-purple-500 rounded-xl flex-shrink-0 relative p-1">
           {imageUrl ? (
             <>

--- a/components/HistoryNew/HistoryDeckCard.tsx
+++ b/components/HistoryNew/HistoryDeckCard.tsx
@@ -30,7 +30,7 @@ export const HistoryDeckCard = ({ deck }: HistoryDeckCardProps) => {
   const isDeckRevealed = currentDate > revealAtDate;
 
   const linkPath = getDeckPath(id);
-  console.log(answerCount, deck);
+
   return (
     <a
       href={linkPath}

--- a/components/HistoryNew/HistoryList.tsx
+++ b/components/HistoryNew/HistoryList.tsx
@@ -2,13 +2,13 @@
 
 import HistoryListSkeleton from "@/app/components/HistoryListSkeleton/HistoryListSkeleton";
 import LoadMore from "@/app/components/LoadMore/LoadMore";
-import NewHistoryHeader from "@/app/components/NewHistoryHeader/NewHistoryHeader";
 import NoDeck from "@/app/components/NoDecks/NoDeck";
 import { HISTORY_DECK_LIMIT } from "@/app/constants/decks";
 import { DeckHistoryItem } from "@/types/history";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 
+import NewHistoryHeader from "../NewHistoryHeader/NewHistoryHeader";
 import { HistoryDeckCard } from "./HistoryDeckCard";
 
 export default function HistoryList() {
@@ -27,8 +27,7 @@ export default function HistoryList() {
       },
       initialPageParam: 1,
       getNextPageParam: (lastPage, allPages) => {
-        // Get total_count from the API response structure
-        const totalCount = lastPage.history[0]?.total_count; // Updated this line
+        const totalCount = lastPage.history[0]?.total_count;
         const totalPages = totalCount
           ? Math.ceil(totalCount / HISTORY_DECK_LIMIT)
           : allPages.length;
@@ -42,9 +41,9 @@ export default function HistoryList() {
       (acc: DeckHistoryItem[], page: { history: DeckHistoryItem[] }) => {
         return [...acc, ...page.history];
       },
-      [], // Initial empty array of DeckHistoryItem[]
+      [],
     );
-  }, [data]);
+  }, [data?.pages]);
 
   return (
     <>

--- a/components/HistoryNew/HistoryList.tsx
+++ b/components/HistoryNew/HistoryList.tsx
@@ -3,18 +3,21 @@
 import { getHistoryDecks } from "@/app/actions/history";
 import HistoryListSkeleton from "@/app/components/HistoryListSkeleton/HistoryListSkeleton";
 import LoadMore from "@/app/components/LoadMore/LoadMore";
+import NewHistoryHeader from "@/app/components/NewHistoryHeader/NewHistoryHeader";
 import NoDeck from "@/app/components/NoDecks/NoDeck";
 import { HISTORY_DECK_LIMIT } from "@/app/constants/decks";
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { HistoryDeckCard } from "./HistoryDeckCard";
 
 export default function HistoryList() {
+  const [showAnsweredDeck, setShowAnsweredDeck] = useState(true);
   const { data, isLoading, fetchNextPage, hasNextPage, isFetching } =
     useInfiniteQuery({
-      queryKey: ["history-decks"],
-      queryFn: ({ pageParam }) => getHistoryDecks({ pageParam }),
+      queryKey: ["history-decks", showAnsweredDeck],
+      queryFn: ({ pageParam }) =>
+        getHistoryDecks({ pageParam, showAnsweredDeck }),
       initialPageParam: 1,
       getNextPageParam: (lastPage, allPages) => {
         const totalCount = lastPage?.[0]?.total_count;
@@ -44,19 +47,25 @@ export default function HistoryList() {
   if (isLoading) return <HistoryListSkeleton />;
 
   return (
-    <div className="flex flex-col gap-2 overflow-hidden">
-      <ul className="flex flex-col gap-2 overflow-y-auto pb-2">
-        {formattedData?.map((deck) => (
-          <li key={deck.id}>
-            <HistoryDeckCard deck={deck} />
-          </li>
-        ))}
-      </ul>
-      <LoadMore
-        isFetching={isFetching}
-        fetchNextPage={fetchNextPage}
-        hasNextPage={hasNextPage}
+    <>
+      <NewHistoryHeader
+        handleToggleChange={() => setShowAnsweredDeck(!showAnsweredDeck)}
+        showAnsweredDeck={showAnsweredDeck}
       />
-    </div>
+      <div className="flex flex-col gap-2 overflow-hidden">
+        <ul className="flex flex-col gap-2 overflow-y-auto pb-2">
+          {formattedData?.map((deck) => (
+            <li key={deck.id}>
+              <HistoryDeckCard deck={deck} />
+            </li>
+          ))}
+        </ul>
+        <LoadMore
+          isFetching={isFetching}
+          fetchNextPage={fetchNextPage}
+          hasNextPage={hasNextPage}
+        />
+      </div>
+    </>
   );
 }

--- a/components/HistoryNew/HistoryList.tsx
+++ b/components/HistoryNew/HistoryList.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { getHistoryDecks } from "@/app/actions/history";
 import HistoryListSkeleton from "@/app/components/HistoryListSkeleton/HistoryListSkeleton";
 import LoadMore from "@/app/components/LoadMore/LoadMore";
 import NewHistoryHeader from "@/app/components/NewHistoryHeader/NewHistoryHeader";
 import NoDeck from "@/app/components/NoDecks/NoDeck";
 import { HISTORY_DECK_LIMIT } from "@/app/constants/decks";
+import { DeckHistoryItem } from "@/types/history";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 
@@ -16,25 +16,34 @@ export default function HistoryList() {
   const { data, isLoading, fetchNextPage, hasNextPage, isFetching } =
     useInfiniteQuery({
       queryKey: ["history-decks", showAnsweredDeck],
-      queryFn: ({ pageParam }) =>
-        getHistoryDecks({ pageParam, showAnsweredDeck }),
+      queryFn: async ({
+        pageParam,
+      }): Promise<{ history: Array<DeckHistoryItem> }> => {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/history/deck?pageParam=${pageParam}&showAnsweredDeck=${showAnsweredDeck}`,
+        );
+        if (!response.ok) throw new Error("Error getting decks history");
+        return await response.json();
+      },
       initialPageParam: 1,
       getNextPageParam: (lastPage, allPages) => {
-        const totalCount = lastPage?.[0]?.total_count;
+        // Get total_count from the API response structure
+        const totalCount = lastPage.history[0]?.total_count; // Updated this line
         const totalPages = totalCount
           ? Math.ceil(totalCount / HISTORY_DECK_LIMIT)
           : allPages.length;
-        if (totalPages === allPages.length) {
-          return undefined;
-        }
-        return allPages.length + 1;
+
+        return allPages.length < totalPages ? allPages.length + 1 : undefined;
       },
     });
 
   const formattedData = useMemo(() => {
-    return data?.pages.reduce((acc, page) => {
-      return [...acc, ...page];
-    }, []);
+    return data?.pages.reduce<DeckHistoryItem[]>(
+      (acc: DeckHistoryItem[], page: { history: DeckHistoryItem[] }) => {
+        return [...acc, ...page.history];
+      },
+      [], // Initial empty array of DeckHistoryItem[]
+    );
   }, [data]);
 
   return (

--- a/components/HistoryNew/HistoryList.tsx
+++ b/components/HistoryNew/HistoryList.tsx
@@ -37,35 +37,40 @@ export default function HistoryList() {
     }, []);
   }, [data]);
 
-  if (
-    (formattedData?.length === 0 || formattedData === undefined) &&
-    !isFetching
-  ) {
-    return <NoDeck />;
-  }
-
-  if (isLoading) return <HistoryListSkeleton />;
-
   return (
     <>
       <NewHistoryHeader
         handleToggleChange={() => setShowAnsweredDeck(!showAnsweredDeck)}
         showAnsweredDeck={showAnsweredDeck}
       />
-      <div className="flex flex-col gap-2 overflow-hidden">
-        <ul className="flex flex-col gap-2 overflow-y-auto pb-2">
-          {formattedData?.map((deck) => (
-            <li key={deck.id}>
-              <HistoryDeckCard deck={deck} />
-            </li>
-          ))}
-        </ul>
-        <LoadMore
-          isFetching={isFetching}
-          fetchNextPage={fetchNextPage}
-          hasNextPage={hasNextPage}
-        />
-      </div>
+      {isLoading ? (
+        <HistoryListSkeleton />
+      ) : (
+        <>
+          {/* Check for empty or undefined data */}
+          {formattedData?.length === 0 || formattedData === undefined ? (
+            <NoDeck />
+          ) : (
+            <div className="flex flex-col gap-2 overflow-hidden">
+              {/* List of Decks */}
+              <ul className="flex flex-col gap-2 overflow-y-auto pb-2">
+                {formattedData?.map((deck) => (
+                  <li key={deck.id}>
+                    <HistoryDeckCard deck={deck} />
+                  </li>
+                ))}
+              </ul>
+
+              {/* Load More Button */}
+              <LoadMore
+                isFetching={isFetching}
+                fetchNextPage={fetchNextPage}
+                hasNextPage={hasNextPage}
+              />
+            </div>
+          )}
+        </>
+      )}
     </>
   );
 }

--- a/components/NewHistoryHeader/NewHistoryHeader.tsx
+++ b/components/NewHistoryHeader/NewHistoryHeader.tsx
@@ -1,9 +1,8 @@
 "use client";
 
+import { InfoIcon } from "@/app/components/Icons/InfoIcon";
+import InfoDrawer from "@/app/components/InfoDrawer/InfoDrawer";
 import React, { useState } from "react";
-
-import { InfoIcon } from "../Icons/InfoIcon";
-import InfoDrawer from "../InfoDrawer/InfoDrawer";
 
 function NewHistoryHeader({
   handleToggleChange,

--- a/lib/history/deck.ts
+++ b/lib/history/deck.ts
@@ -1,0 +1,26 @@
+import { HISTORY_DECK_LIMIT } from "@/app/constants/decks";
+import {
+  getAnsweredDecksForHistory,
+  getDecksForHistory,
+} from "@/app/queries/history";
+import { DeckHistoryItem } from "@/types/history";
+import "server-only";
+
+export const getHistoryDecks = async ({
+  pageParam,
+  showAnsweredDeck,
+  userId,
+}: {
+  pageParam: number;
+  showAnsweredDeck: boolean;
+  userId: string | undefined;
+}): Promise<DeckHistoryItem[]> => {
+  if (!userId) {
+    return [];
+  }
+  if (showAnsweredDeck) {
+    return getAnsweredDecksForHistory(userId, HISTORY_DECK_LIMIT, pageParam);
+  } else {
+    return getDecksForHistory(userId, HISTORY_DECK_LIMIT, pageParam);
+  }
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,9 @@ const colors = {
   },
 
   chomp: {
+    indigo: {
+      dark: "#363548",
+    },
     blue: {
       dark: "#89E0CD",
       light: "#D6FCF4",

--- a/types/history.ts
+++ b/types/history.ts
@@ -7,4 +7,5 @@ export type DeckHistoryItem = {
   total_potential_reward_amount: number;
   total_credit_cost: number;
   total_count: number;
+  answerCount?: number;
 };

--- a/types/history.ts
+++ b/types/history.ts
@@ -7,5 +7,6 @@ export type DeckHistoryItem = {
   total_potential_reward_amount: number;
   total_credit_cost: number;
   total_count: number;
-  answerCount?: number;
+  answeredQuestions: number;
+  totalQuestions: number;
 };


### PR DESCRIPTION
New toggle in history section to show unanswered deck when the toggle is off with dark background color. Answered deck will be shown in purplish color 
Key points
- Default behavior is for 'only deck's i've answered' to be on
- Add info popup
- Ordering of cards is not impacted by the filter