### PR TITLE
PROD-1017: Fix 0 BONK in deck history

### DIFF
--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -378,7 +378,7 @@ export async function getAnsweredDecksForHistory(
       d.deck,
       d."imageUrl",
       d."revealAtDate",
-      COALESCE(SUM(dr."bonkReward"), 0) AS "total_reward_amount",  -- Fixed aggregation
+      COALESCE(SUM(CAST(dr."bonkReward" AS NUMERIC)), 0) AS "total_reward_amount",
       COALESCE((SELECT SUM(q."revealTokenAmount") 
        FROM public."DeckQuestion" dq
        JOIN public."Question" q 
@@ -427,7 +427,7 @@ export async function getAnsweredDecksForHistory(
     history_deck_cte, total_count
   ORDER BY 
     history_deck_cte."revealAtDate" DESC,
-    history_deck_cte.id DESC  -- Added secondary sort
+    history_deck_cte.id DESC
   LIMIT ${pageSize} OFFSET ${offset}
   `;
 
@@ -448,7 +448,7 @@ export async function getDecksForHistory(
       d.deck,
       d."imageUrl",
       d."revealAtDate",
-      COALESCE(SUM(dr."bonkReward"), 0) AS "total_reward_amount", -- Aggregate rewards
+      COALESCE(SUM(CAST(dr."bonkReward" AS NUMERIC)), 0) AS "total_reward_amount",
       COALESCE((SELECT SUM(q."revealTokenAmount") 
        FROM public."DeckQuestion" dq
        JOIN public."Question" q 

--- a/components/HistoryNew/HistoryList.tsx
+++ b/components/HistoryNew/HistoryList.tsx
@@ -23,7 +23,16 @@ export default function HistoryList() {
           `${process.env.NEXT_PUBLIC_API_URL}/history/deck?pageParam=${pageParam}&showAnsweredDeck=${showAnsweredDeck}`,
         );
         if (!response.ok) throw new Error("Error getting decks history");
-        return await response.json();
+        const result = await response.json();
+        if (!result?.history || !Array.isArray(result.history))
+          throw new Error("Error parsing deck history");
+
+        result.history = result.history.map((item: any) => ({
+          ...item,
+          revealAtDate: new Date(item.revealAtDate),
+        }));
+
+        return result;
       },
       initialPageParam: 1,
       getNextPageParam: (lastPage, allPages) => {


### PR DESCRIPTION
Fixes the issue with 0 BONK displayed in the deck history. It was due to an invalid date comparison between a Date object and string.