### PR TITLE
fix: do not use schema-only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -212,8 +212,7 @@ jobs:
               --data "{
                 \"branch\": {
                   \"parent_id\": \"$parent_id\",
-                  \"name\": \"$TEST_BRANCH\",
-                  \"init_source\": \"schema-only\"
+                  \"name\": \"$TEST_BRANCH\"
                 },
                 \"endpoints\": [
                   {
@@ -344,8 +343,7 @@ jobs:
                 --data "{
                   \"branch\": {
                     \"parent_id\": \"$parent_id\",
-                    \"name\": \"$TEST_BRANCH\",
-                    \"init_source\": \"schema-only\"
+                    \"name\": \"$TEST_BRANCH\"
                   },
                   \"endpoints\": [
                     {


### PR DESCRIPTION
The schema-only option creates a new root branch. We are only allowed a limited number of root branches so we cannot create a new schema-only branch liberally. schema-only prevents the DB from having any data when test starts. But that really shouldn't be a requirement for our tests anyways.

![Screenshot 2025-04-14 at 22 13 43](https://github.com/user-attachments/assets/f65305ec-ddad-4b34-8565-0636cf1eb370)

An alternative approach would be to delete branches after test completes. But that will make debugging errors more difficult.