### PR TITLE
PROD-1033 update error state of ask copy

### DIFF
--- a/__tests__/actions/ask/question.test.ts
+++ b/__tests__/actions/ask/question.test.ts
@@ -60,7 +60,7 @@ describe("createAskQuestion", () => {
     const result = await createAskQuestion(invalidData);
 
     expect(result).toEqual({
-      errorMessage: "Question: String must contain at least 5 character(s)",
+      errorMessage: "Question: This field must have at least 5 characters.",
       success: false,
     });
   });

--- a/app/schemas/ask.ts
+++ b/app/schemas/ask.ts
@@ -19,8 +19,12 @@ export const askQuestionSchema = z.object({
       invalid_type_error: "Invalid question",
       required_error: "Question is required",
     })
-    .min(MIN_QUESTION_LENGTH)
-    .max(MAX_QUESTION_LENGTH),
+    .min(MIN_QUESTION_LENGTH, {
+      message: `This field must have at least ${MIN_QUESTION_LENGTH} characters`,
+    })
+    .max(MAX_QUESTION_LENGTH, {
+      message: `This field can have up to ${MAX_QUESTION_LENGTH} characters`,
+    }),
   type: z.nativeEnum(QuestionType),
   file: z
     .custom<File[]>()
@@ -39,7 +43,14 @@ export const askQuestionSchema = z.object({
     }, "Only .jpg, .jpeg, .png and .webp formats are supported."),
   questionOptions: z
     .object({
-      option: z.string().min(MIN_OPTION_LENGTH).max(MAX_OPTION_LENGTH),
+      option: z
+        .string()
+        .min(MIN_OPTION_LENGTH, {
+          message: `This field must have at least ${MIN_OPTION_LENGTH} characters`,
+        })
+        .max(MAX_OPTION_LENGTH, {
+          message: `This field can have up to ${MAX_OPTION_LENGTH} characters`,
+        }),
     })
     .array(),
   imageUrl: z

--- a/app/schemas/ask.ts
+++ b/app/schemas/ask.ts
@@ -20,10 +20,10 @@ export const askQuestionSchema = z.object({
       required_error: "Question is required",
     })
     .min(MIN_QUESTION_LENGTH, {
-      message: `This field must have at least ${MIN_QUESTION_LENGTH} characters`,
+      message: `This field must have at least ${MIN_QUESTION_LENGTH} characters.`,
     })
     .max(MAX_QUESTION_LENGTH, {
-      message: `This field can have up to ${MAX_QUESTION_LENGTH} characters`,
+      message: `This field can have up to ${MAX_QUESTION_LENGTH} characters.`,
     }),
   type: z.nativeEnum(QuestionType),
   file: z
@@ -46,10 +46,10 @@ export const askQuestionSchema = z.object({
       option: z
         .string()
         .min(MIN_OPTION_LENGTH, {
-          message: `This field must have at least ${MIN_OPTION_LENGTH} characters`,
+          message: `This field must have at least ${MIN_OPTION_LENGTH} characters.`,
         })
         .max(MAX_OPTION_LENGTH, {
-          message: `This field can have up to ${MAX_OPTION_LENGTH} characters`,
+          message: `This field can have up to ${MAX_OPTION_LENGTH} characters.`,
         }),
     })
     .array(),


### PR DESCRIPTION
Update the error message on ASK components Question and Answer Choice

The error was left under the input field since that was an option on the issue.

The new error text should appear as:

`This field can have up to 40 characters.`

Also added the next error to match them both:

`This field must have at least 5 characters.`