### PR TITLE
PROD-1045 make mystery box campaigns hideable

### DIFF
--- a/lib/mysteryBox/createCampaignMysteryBox.ts
+++ b/lib/mysteryBox/createCampaignMysteryBox.ts
@@ -13,18 +13,14 @@ import "server-only";
 import { getBonkAddress } from "../env-vars";
 
 /**
- * @description Validate campaign details. Create new mystery box if doesn't exist else return the existing mb id for new and unclaimed box.
- * @param {string} userId - The unique identifier of the user
- * @param {string} [campaignBoxId] - Optional. The identifier of the campaign box
- * @returns {Promise<string[]>} A promise that resolves to an array of string IDs representing mystery box identifiers
+ * Validate campaign details.
+ * Create new mystery box if doesn't exist else return the existing mb id for new and unclaimed box.
  */
-
 export const createCampaignMysteryBox = async (
   userId: string,
   campaignBoxId?: string,
-) => {
+): Promise<string[] | null> => {
   const userWallet = await prisma.wallet.findFirst({ where: { userId } });
-
   if (!userWallet) return null;
 
   if (!campaignBoxId) {

--- a/lib/mysteryBox/getCampaigns.ts
+++ b/lib/mysteryBox/getCampaigns.ts
@@ -4,15 +4,15 @@ import { EMysteryBoxStatus } from "@prisma/client";
 import "server-only";
 
 /**
- * @description Get new and unclaimed campaigns allowed for user
- * @returns {Array<Object>} An array containing a single object with item details
- * @returns {string} returns[0].id - Unique identifier for the item
- * @returns {string} returns[0].name - Name of the item
- * @returns {string} returns[0].infoTitle - Title of the item's information
- * @returns {string} returns[0].infoBody - Body text of the item's information
- * @returns {boolean} returns[0].isEligible - Eligibility status of the item
+ * Get new and unclaimed campaigns allowed for user
  */
-export const getCampaigns = async () => {
+export const getCampaigns = async (): Promise<Array<{
+  id: string;
+  name: string;
+  infoTitle: string;
+  infoBody: string;
+  isEligible: boolean;
+}> | null> => {
   const payload = await getJwtPayload();
 
   if (!payload) {
@@ -28,7 +28,9 @@ export const getCampaigns = async () => {
 
   if (!userWallet) return null;
 
-  const campaignBoxes = await prisma.campaignMysteryBox.findMany();
+  const campaignBoxes = await prisma.campaignMysteryBox.findMany({
+    where: { enabled: true },
+  });
 
   const validCampaignBoxes = await prisma.campaignMysteryBoxAllowlist.findMany({
     where: {

--- a/prisma/migrations/20250423161120_add_enabled_field_for_campaign_mystery_box/migration.sql
+++ b/prisma/migrations/20250423161120_add_enabled_field_for_campaign_mystery_box/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "CampaignMysteryBox" ADD COLUMN     "enabled" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -379,6 +379,7 @@ model CampaignMysteryBox {
   CampaignMysteryBoxAllowlist CampaignMysteryBoxAllowlist[]
   MysteryBoxTrigger           MysteryBoxTrigger[]
   boxType                     String
+  enabled                     Boolean                       @default(true)
 }
 
 model CampaignMysteryBoxAllowlist {


### PR DESCRIPTION
Should be possible to hide campaigns from Mystery Box page. It will not be possible to claim MBP for campaigns that have been hidden.

Un/hide will be done by a dev, directly accessing DB.

