### PR TITLE
PROD-1039: Automatic question skipping

### DIFF
--- a/__tests__/actions/answer/answer.test.ts
+++ b/__tests__/actions/answer/answer.test.ts
@@ -234,6 +234,14 @@ describe("Validate points logs for completing questions and decks", () => {
       if (i == randomRes) expect(questionAnswer[i].percentage).toBe(50);
       else expect(questionAnswer[i].percentage).toBeNull();
     }
+
+    // Calling again should succeed and return the existing result
+
+    await expect(
+      markQuestionAsSeenButNotAnswered(deckQuestionId),
+    ).resolves.toEqual(
+      expect.objectContaining({ random: seenQuestion?.random }),
+    );
   });
 
   it("should not allow a user to answer the same question twice", async () => {


### PR DESCRIPTION
I've been unable to reproduce the auto-skipping behaviour locally or on prod, but from the logs it seems like the action is being called multiple times for one question, triggering an exception and the skipped-question phenomenon. Possibly ultimately due to a weird dependency issue with the hook on the frontend.

For now I've updated the action to quietly do nothing if called with the same question, which I think makes sense anyway.