### PR TITLE
PROD-1039: automatic skipping of questions (2)

### DIFF
--- a/__tests__/db/triggers/ask-points.test.ts
+++ b/__tests__/db/triggers/ask-points.test.ts
@@ -297,4 +297,33 @@ describe("Ask DB triggers", () => {
 
     await prisma.deckQuestion.delete({ where: { id: dq.id } });
   });
+
+  it("should invoke acceptance trigger for community deck", async () => {
+    const schemaName = `test_schema_${new Date().getTime()}`;
+    const userId = users[1].id;
+
+    const option = await prisma.questionOption.findFirstOrThrow({
+      where: {
+        questionId: questions[1].id,
+      },
+    });
+
+    const optionId = option.id;
+
+    await prisma.$queryRawUnsafe(`CREATE SCHEMA ${schemaName}`);
+    await prisma.$queryRawUnsafe(`SET search_path TO ${schemaName}`);
+
+    await expect(prisma.$queryRaw`
+      INSERT INTO public."QuestionAnswer" (
+        "questionOptionId", "userId", "status", "selected", "percentage", "uuid"
+      ) VALUES (
+        ${optionId}, ${userId}, 'Viewed', true, 50, gen_random_uuid()
+      )`).resolves.not.toThrow();
+
+    await prisma.$queryRawUnsafe(`DROP SCHEMA ${schemaName}`);
+
+    await prisma.questionAnswer.deleteMany({
+      where: { questionOptionId: optionId, userId: userId },
+    });
+  });
 });

--- a/__tests__/db/triggers/ask-points.test.ts
+++ b/__tests__/db/triggers/ask-points.test.ts
@@ -298,7 +298,7 @@ describe("Ask DB triggers", () => {
     await prisma.deckQuestion.delete({ where: { id: dq.id } });
   });
 
-  it("should invoke acceptance trigger for community deck", async () => {
+  it("should verify the trigger can handle an unexpected schema prefix context", async () => {
     const schemaName = `test_schema_${new Date().getTime()}`;
     const userId = users[1].id;
 

--- a/__tests__/lib/v1/answerQuestion.test.ts
+++ b/__tests__/lib/v1/answerQuestion.test.ts
@@ -17,8 +17,6 @@ describe("answerQuestion", () => {
   let questionIds: number[] = [];
   let questionUuids: string[] = [];
   let question0OptionUuids: string[] = [];
-  let question1OptionUuids: string[] = [];
-  let otherUsers: { id: string; username: string }[] = [];
 
   beforeAll(async () => {
     await prisma.$transaction(async (tx) => {
@@ -117,7 +115,6 @@ describe("answerQuestion", () => {
       questionUuids = questions.map((q) => q.uuid);
 
       question0OptionUuids = questions[0].questionOptions.map((qo) => qo.uuid);
-      question1OptionUuids = questions[1].questionOptions.map((qo) => qo.uuid);
 
       await tx.deckQuestion.createMany({
         data: [
@@ -150,12 +147,6 @@ describe("answerQuestion", () => {
       await tx.question.deleteMany({ where: { id: { in: questionIds } } });
       await tx.deck.deleteMany({ where: { id: { equals: deckId } } });
       await tx.user.deleteMany({ where: { id: { equals: user1.id } } });
-
-      if (otherUsers.length > 0) {
-        await tx.user.deleteMany({
-          where: { id: { in: otherUsers.map((user) => user.id) } },
-        });
-      }
     });
   });
 

--- a/__tests__/v1/questions/answer.route.test.ts
+++ b/__tests__/v1/questions/answer.route.test.ts
@@ -1,6 +1,5 @@
 import prisma from "@/app/services/prisma";
 import { POST } from "@/app/v1/questions/[id]/answer/route";
-import { faker } from "@faker-js/faker";
 import { QuestionType, Token } from "@prisma/client";
 import bs58 from "bs58";
 import dayjs from "dayjs";

--- a/app/queries/history.ts
+++ b/app/queries/history.ts
@@ -231,10 +231,10 @@ export async function getNewHistoryQuery(
     q.question AS "question",
     q."revealAtDate" AS "revealAtDate",
     COALESCE(uqas."indicatorType", 'unseen') AS "indicatorType"
-    FROM "Question" q
+    FROM public."Question" q
     JOIN public."DeckQuestion" dq ON dq."questionId" = q.id
     JOIN public."Deck" d ON d.id = dq."deckId" AND (${getAllDecks} IS TRUE OR dq."deckId" = ${deckId})
-    LEFT JOIN "UserQuestionAnswerStatus" uqas ON uqas."questionId" = q.id AND uqas."userId" = ${userId}
+    LEFT JOIN public."UserQuestionAnswerStatus" uqas ON uqas."questionId" = q.id AND uqas."userId" = ${userId}
     ORDER BY q.id DESC
     LIMIT ${pageSize} OFFSET ${offset}
   `;
@@ -254,10 +254,10 @@ export async function getHistoryHeadersData(
         SELECT
         q.id AS "id",
         COALESCE(uqas."indicatorType", 'unseen') AS "indicatorType"
-        FROM "Question" q
+        FROM public."Question" q
         JOIN public."DeckQuestion" dq ON dq."questionId" = q.id
         JOIN public."Deck" d ON d.id = dq."deckId" AND (${getAllDecks} IS TRUE OR dq."deckId" = ${deckId})
-        LEFT JOIN "UserQuestionAnswerStatus" uqas ON uqas."questionId" = q.id AND uqas."userId" = ${userId}
+        LEFT JOIN public."UserQuestionAnswerStatus" uqas ON uqas."questionId" = q.id AND uqas."userId" = ${userId}
     ) AS sub
     GROUP BY sub."indicatorType"
 `;
@@ -320,14 +320,14 @@ export async function getAllDeckQuestionsReadyForReveal(
 FROM 
     public."Question" q
 LEFT JOIN 
-    "ChompResult" cr ON cr."questionId" = q.id
+    public."ChompResult" cr ON cr."questionId" = q.id
     AND cr."userId" = ${userId}
     AND cr."transactionStatus" IN ('Completed', 'Pending')
 JOIN 
-    "QuestionOption" qo ON q.id = qo."questionId"
+    public."QuestionOption" qo ON q.id = qo."questionId"
 JOIN 
-    "QuestionAnswer" qa ON qo.id = qa."questionOptionId"
-JOIN "DeckQuestion" dc ON q.id = dc."questionId"
+    public."QuestionAnswer" qa ON qo.id = qa."questionOptionId"
+JOIN public."DeckQuestion" dc ON q.id = dc."questionId"
 WHERE 
     (cr."transactionStatus" IS NULL OR cr."transactionStatus" != 'Completed')
     AND q."revealAtDate" IS NOT NULL
@@ -377,7 +377,7 @@ export async function getAnsweredDecksForHistory(
        WHERE dq."deckId" = d.id) AS "totalQuestions"
     FROM 
       public."Deck" d
-    LEFT JOIN "DeckRewards" dr ON dr."userId" = ${userId} AND dr."deckId" = d.id
+    LEFT JOIN public."DeckRewards" dr ON dr."userId" = ${userId} AND dr."deckId" = d.id
     WHERE 
       d."revealAtDate" IS NOT NULL
       AND EXISTS (
@@ -446,7 +446,7 @@ export async function getDecksForHistory(
        WHERE dq."deckId" = d.id) AS "totalQuestions"
     FROM 
       public."Deck" d
-    LEFT JOIN "DeckRewards" dr ON dr."userId" = ${userId} AND dr."deckId" = d.id
+    LEFT JOIN public."DeckRewards" dr ON dr."userId" = ${userId} AND dr."deckId" = d.id
     WHERE 
       d."revealAtDate" IS NOT NULL
       AND d."revealAtDate" <= NOW()

--- a/app/v1/questions/[id]/answer/route.ts
+++ b/app/v1/questions/[id]/answer/route.ts
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest, params: AnswerQuestionParams) {
     return NextResponse.json({
       answerId: uuid,
     });
-  } catch (e) {
+  } catch {
     if (e instanceof ApiError) {
       return NextResponse.json(
         { error: e.error, message: e.message },

--- a/app/v1/questions/[id]/answer/route.ts
+++ b/app/v1/questions/[id]/answer/route.ts
@@ -87,7 +87,7 @@ export async function POST(request: NextRequest, params: AnswerQuestionParams) {
 
     try {
       userId = await findOrCreateUser(req.data.userAddress);
-    } catch (e) {
+    } catch {
       throw new ApiUserInvalidError("Could not find or create user account");
     }
 
@@ -103,7 +103,7 @@ export async function POST(request: NextRequest, params: AnswerQuestionParams) {
     return NextResponse.json({
       answerId: uuid,
     });
-  } catch {
+  } catch (e) {
     if (e instanceof ApiError) {
       return NextResponse.json(
         { error: e.error, message: e.message },

--- a/lib/mysteryBox.ts
+++ b/lib/mysteryBox.ts
@@ -28,11 +28,11 @@ export async function calculateTotalPrizeTokens(
 ) {
   const result = (await prisma.$queryRaw`
     SELECT SUM(CAST(amount AS NUMERIC)) FROM
-      "MysteryBoxPrize" mbp
-      LEFT JOIN "MysteryBoxTrigger" mbt
+      public."MysteryBoxPrize" mbp
+      LEFT JOIN public."MysteryBoxTrigger" mbt
       ON mbp."mysteryBoxTriggerId" = mbt."id"
       LEFT JOIN
-      "MysteryBox" mb
+      public."MysteryBox" mb
       ON mbt."mysteryBoxId" = mb."id"
       WHERE mb."userId" = ${userId}
       AND mbp."prizeType" = 'Token'

--- a/prisma/migrations/20250508151300_qualify_trigger_table_refs/migration.sql
+++ b/prisma/migrations/20250508151300_qualify_trigger_table_refs/migration.sql
@@ -1,0 +1,158 @@
+-- Gives the asker of a community "ask" question a point when
+-- another user answers a question.
+CREATE OR REPLACE FUNCTION reward_answered_community_ask_question_asker()
+RETURNS TRIGGER AS $$
+DECLARE
+    "REWARD_FOR_ANSWERED_QUESTION" CONSTANT DECIMAL = 1;
+    "v_questionId" INT;
+    "v_questionAsker" TEXT;
+    "v_isSubmittedByUser" BOOLEAN;
+    "v_aqaId" INT;
+BEGIN
+    SELECT
+        "questionId" INTO "v_questionId"
+    FROM
+        public."QuestionOption"
+    WHERE "id" = NEW."questionOptionId";
+
+    SELECT
+        "isSubmittedByUser", "createdByUserId" INTO "v_isSubmittedByUser", "v_questionAsker"
+    FROM
+        public."Question"
+    WHERE "id" = "v_questionId";
+
+    -- Check if this is a user submitted question and then check
+    -- if we've already rewarded this question by looking for an
+    -- entry in the "AskQuestionAnswer" table.
+    --
+    -- We also require a first-order and second order response in
+    -- order to be eligible for a reward.
+    IF "v_isSubmittedByUser" IS TRUE AND "v_questionAsker" IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM public."AskQuestionAnswer"
+        WHERE "userId" = NEW."userId"
+        AND "questionId" = "v_questionId"
+    ) AND (
+        -- We need to check that:
+        -- a) A first-order option was selected:
+        --    possibly this one, possibly already
+        --    inserted.
+        -- b) A second-order percentage was given:
+        --    again, could be another option, and
+        --    possibly the options with the 1st/2nd
+        --    order are different.
+        (NEW."percentage" IS NOT NULL OR EXISTS (
+          SELECT 1
+          FROM public."QuestionAnswer" qa
+          LEFT JOIN public."QuestionOption" qo
+          ON qa."questionOptionId" = qo."id"
+          WHERE qo."questionId" = "v_questionId"
+          AND "percentage" IS NOT NULL
+          AND "userId" = NEW."userId"
+        )) AND (
+          NEW."selected" IS TRUE OR EXISTS (
+          SELECT 1
+          FROM public."QuestionAnswer" qa
+          LEFT JOIN public."QuestionOption" qo
+          ON qa."questionOptionId" = qo."id"
+          WHERE qo."questionId" = "v_questionId"
+          AND "selected" IS TRUE
+          AND "userId" = NEW."userId"
+        ))
+    ) THEN
+        INSERT INTO public."AskQuestionAnswer" (
+            "userId",
+            "questionId"
+        ) VALUES (
+            NEW."userId",
+            "v_questionId"
+        ) RETURNING "id" INTO "v_aqaId";
+
+        INSERT INTO public."FungibleAssetTransactionLog" (
+            "userId",
+            "askQuestionAnswerId",
+            "type",
+            "asset",
+            "change"
+        ) VALUES (
+            "v_questionAsker",
+            "v_aqaId",
+            'AskQuestionAnswered',
+            'Point',
+            "REWARD_FOR_ANSWERED_QUESTION"
+        );
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for the above
+
+CREATE OR REPLACE TRIGGER trigger_reward_answered_community_ask_question_asker
+AFTER INSERT OR UPDATE ON public."QuestionAnswer"
+FOR EACH ROW
+EXECUTE FUNCTION reward_answered_community_ask_question_asker();
+
+-------------------------------------------------------------------------------
+
+-- Gives the asker of a community "ask" question points when
+-- their answer is accepted, which we detect by its addition
+-- into a parent deck in the community ask stack.
+CREATE OR REPLACE FUNCTION reward_accepted_community_ask_question_asker()
+RETURNS TRIGGER AS $$
+DECLARE
+    "REWARD_FOR_ACCEPTED_QUESTION" CONSTANT DECIMAL = 69;
+    "v_questionId" INT;
+    "v_stackId" INT;
+    "v_questionAsker" TEXT;
+    "v_isSubmittedByUser" BOOLEAN;
+BEGIN
+    SELECT
+        "isSubmittedByUser", "createdByUserId"
+    INTO
+        "v_isSubmittedByUser", "v_questionAsker"
+    FROM
+        public."Question"
+    WHERE
+        "id" = NEW."questionId";
+
+    SELECT
+      "stackId"
+    INTO
+      "v_stackId"
+    FROM
+      public."Deck"
+    WHERE
+      "id" = NEW."deckId";
+
+    -- Check if this is a user submitted question, being added to
+    -- a deck in the community stack, and then check if we've
+    -- already rewarded this question by looking for an existing
+    -- entry in the FATL table.
+    IF "v_isSubmittedByUser" IS TRUE AND "v_questionAsker" IS NOT NULL AND EXISTS (
+        SELECT 1
+        FROM public."Stack"
+        WHERE "specialId" = 'CommunityAsk'
+        AND "id" = "v_stackId"
+    ) AND NOT EXISTS (
+        SELECT 1
+        FROM public."FungibleAssetTransactionLog"
+        WHERE "userId" = "v_questionAsker"
+        AND "type" = 'AskQuestionAccepted'
+        AND "questionId" = NEW."questionId"
+    ) THEN
+        INSERT INTO public."FungibleAssetTransactionLog" ("userId", "type", "asset", "change")
+        VALUES ("v_questionAsker", 'AskQuestionAccepted', 'Point', "REWARD_FOR_ACCEPTED_QUESTION");
+    END IF;
+
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger for the above
+
+CREATE OR REPLACE TRIGGER trigger_reward_accepted_community_ask_question_asker
+AFTER INSERT ON public."DeckQuestion"
+FOR EACH ROW
+EXECUTE FUNCTION reward_accepted_community_ask_question_asker();


### PR DESCRIPTION
This resolves an issue which was causing the question skipping phenomenon. The problem was in the ask trigger which fails randomly if we don't explicitly set a schema prefix.

I imagine there are other instances of this issue in other raw queries throughout the app so we should definitely do an audit, but for now this one is in the answer code path and I believe responsible for the failures we've been seeing.

Edit: I went ahead and found/fixed the other instances of unprefixed tables. This PR also has some other lint fixes.