### PR TITLE
fix(PROD-1055): rerun tests on main without failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,11 +123,13 @@ jobs:
           NEON_PROJECT_ID="${{ secrets.NEON_PROJECT_ID }}"
           NEON_API_KEY="${{ secrets.NEON_API_KEY }}"
           GITHUB_RUN_ID="${{ github.run_id }}"
+          GITHUB_RUN_ATTEMPT="${{ github.run_attempt }}"
           
           echo "Variables set:"
           echo "- BRANCH_NAME: $BRANCH_NAME"
           echo "- NEON_PROJECT_ID: ${NEON_PROJECT_ID:0:5}... (redacted)"
           echo "- GITHUB_RUN_ID: $GITHUB_RUN_ID"
+          echo "- GITHUB_RUN_ATTEMPT: $GITHUB_RUN_ATTEMPT"
           
           if [ -z "$NEON_PROJECT_ID" ]; then
             echo "❌ [Step 6] Error: NEON_PROJECT_ID is not set. Please add it to your GitHub secrets."
@@ -199,8 +201,8 @@ jobs:
             fi
             echo "Found parent branch"
 
-            # Construct a fresh test branch name for each run, e.g. test/main-123456789
-            TEST_BRANCH="test/main-$GITHUB_RUN_ID"
+            # Construct a fresh test branch name for each run, e.g. test/main-123456789-1
+            TEST_BRANCH="test/main-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
             echo "Creating a new Neon branch: $TEST_BRANCH"
 
             echo "Creating branch with endpoint in a single request..."

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CHOMP is the first mini-game product created by Gator Labs. We intend to build o
 
 Prerequisites:
 
-- Install Docker
+- Postgres DB: Neon or your favorite provider
 - Create a [Dynamic](https://www.dynamic.xyz/) account
 - Solana RPC like Helius
 - Solana account priv key for the Treasury


### PR DESCRIPTION
- Tests are failing on main when re-run because the branch name doesn't change. Added the runId to the branch name so it will be unique every time.
- Also added a trivial documentation change. This was just for testing tests.