### PR TITLE
feat: GET /questions endpoint

### DIFF
--- a/__tests__/v1/questions/getQuestions.test.ts
+++ b/__tests__/v1/questions/getQuestions.test.ts
@@ -1,0 +1,190 @@
+import prisma from "@/app/services/prisma";
+import { GET } from "@/app/v1/questions/route";
+import { QuestionType, Token } from "@prisma/client";
+import dayjs from "dayjs";
+import { NextRequest } from "next/server";
+import { v4 as uuidv4 } from "uuid";
+
+const TEST_BACKEND_SECRET = "test-backend-secret-456";
+const SOURCE_ONE = "source-alpha";
+const SOURCE_TWO = "source-beta";
+
+describe("GET /v1/questions API Endpoint", () => {
+  process.env.BACKEND_SECRET = TEST_BACKEND_SECRET;
+
+  // Generate random UUIDs for each test run to avoid collisions
+  const questionData = [
+    {
+      uuid: uuidv4(),
+      question: "Is pineapple a valid pizza topping?",
+      description: "Settle the age-old debate once and for all.",
+      source: SOURCE_ONE,
+      type: QuestionType.BinaryQuestion,
+      activeFromDate: dayjs("2025-06-01T00:00:00Z").toDate(),
+      revealAtDate: null,
+      revealToken: Token.Bonk,
+      revealTokenAmount: 100,
+    },
+    {
+      uuid: uuidv4(),
+      question: "The CIA ran a mind control project called MK-Ultra.",
+      description: "From lizard people to leaked documents...",
+      source: SOURCE_ONE,
+      type: QuestionType.BinaryQuestion,
+      activeFromDate: dayjs("2025-05-01T00:00:00Z").toDate(),
+      revealAtDate: dayjs("2025-05-02T00:00:00Z").toDate(),
+      revealToken: Token.Bonk,
+      revealTokenAmount: 200,
+    },
+    {
+      uuid: uuidv4(),
+      question: "Is water wet?",
+      description: "A classic philosophical question.",
+      source: SOURCE_TWO,
+      type: QuestionType.BinaryQuestion,
+      activeFromDate: dayjs().subtract(1, "day").toDate(),
+      revealAtDate: dayjs().add(1, "day").toDate(),
+      revealToken: Token.Bonk,
+      revealTokenAmount: 5,
+    },
+  ];
+
+  let createdQuestionsDb: any[] = [];
+
+  beforeAll(async () => {
+    // Clean up any existing test questions first
+    await prisma.question.deleteMany({
+      where: {
+        source: {
+          in: [SOURCE_ONE, SOURCE_TWO]
+        }
+      }
+    });
+
+    // Then create our test questions
+    createdQuestionsDb = await Promise.all(
+      questionData.map((qData) => prisma.question.create({ data: qData })),
+    );
+  });
+
+  afterAll(async () => {
+    const questionIds = createdQuestionsDb.map((q) => q.id);
+    await prisma.questionAnswer.deleteMany({ where: { questionOption: { questionId: { in: questionIds } } } });
+    await prisma.questionOption.deleteMany({ where: { questionId: { in: questionIds } } });
+    await prisma.deckQuestion.deleteMany({ where: { questionId: { in: questionIds } } });
+    await prisma.question.deleteMany({ where: { id: { in: questionIds } } });
+    delete process.env.BACKEND_SECRET;
+  });
+
+  async function makeRequest(customHeaders: Record<string, string> = {}) {
+    const headers = new Headers({
+      "backend-secret": TEST_BACKEND_SECRET,
+      source: SOURCE_ONE,
+      ...customHeaders,
+    });
+
+    const mockRequest = {
+      headers,
+    } as unknown as NextRequest;
+
+    return GET(mockRequest);
+  }
+
+  it("should return 401 if no backend-secret is provided", async () => {
+    const mockRequest = {
+      headers: new Headers({
+        source: SOURCE_ONE,
+      }),
+    } as unknown as NextRequest;
+
+    const response = await GET(mockRequest);
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 401 if incorrect backend-secret is provided", async () => {
+    const mockRequest = {
+      headers: new Headers({
+        "backend-secret": "wrong-secret",
+        source: SOURCE_ONE,
+      }),
+    } as unknown as NextRequest;
+
+    const response = await GET(mockRequest);
+    expect(response.status).toBe(401);
+  });
+
+  it("should return 400 if no source header is provided", async () => {
+    const mockRequest = {
+      headers: new Headers({
+        "backend-secret": TEST_BACKEND_SECRET,
+      }),
+    } as unknown as NextRequest;
+
+    const response = await GET(mockRequest);
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.error).toBe("missing_source_header");
+  });
+
+  it("should return questions for a specific source (SOURCE_ONE)", async () => {
+    const response = await makeRequest({ source: SOURCE_ONE });
+    expect(response.status).toBe(200);
+    const questions = await response.json();
+    const expectedQuestions = questionData.filter(q => q.source === SOURCE_ONE);
+    expect(questions.length).toBe(expectedQuestions.length);
+    questions.forEach((q: any) => expect(q.title).toBeDefined()); // Basic check
+    expectedQuestions.forEach(expQ => {
+        const found = questions.find((q:any) => q.questionId === expQ.uuid);
+        expect(found).toBeDefined();
+        expect(found.title).toEqual(expQ.question);
+    });
+  });
+
+  it("should return questions for a specific source (SOURCE_TWO)", async () => {
+    const response = await makeRequest({ source: SOURCE_TWO });
+    expect(response.status).toBe(200);
+    const questions = await response.json();
+    const expectedQuestions = questionData.filter(q => q.source === SOURCE_TWO);
+    expect(questions.length).toBe(expectedQuestions.length);
+    expectedQuestions.forEach(expQ => {
+        const found = questions.find((q:any) => q.questionId === expQ.uuid);
+        expect(found).toBeDefined();
+        expect(found.title).toEqual(expQ.question);
+    });
+  });
+
+  it("should return an empty array if source has no questions", async () => {
+    const response = await makeRequest({ source: "non-existent-source" });
+    expect(response.status).toBe(200);
+    const questions = await response.json();
+    expect(questions).toEqual([]);
+  });
+
+  it("should return all questions for a source, ordered by activeFromDate descending", async () => {
+    const response = await makeRequest({ source: SOURCE_ONE });
+    expect(response.status).toBe(200);
+    const questions = await response.json();
+    const expectedQuestions = questionData.filter(q => q.source === SOURCE_ONE);
+    expect(questions.length).toBe(expectedQuestions.length);
+
+    // Verify content and order (assuming activeFromDate is correctly used by getQuestions)
+    const sortedExpected = expectedQuestions.sort((a,b) => b.activeFromDate.getTime() - a.activeFromDate.getTime());
+    questions.forEach((fetchedQ: any, index: number) => {
+      expect(fetchedQ.questionId).toBe(sortedExpected[index].uuid);
+      expect(fetchedQ.title).toBe(sortedExpected[index].question);
+    });
+
+    if (questions.length >= 2) {
+      const date1 = questions[0].activeAt ? new Date(questions[0].activeAt).getTime() : 0;
+      const date2 = questions[1].activeAt ? new Date(questions[1].activeAt).getTime() : 0;
+      expect(date1).toBeGreaterThanOrEqual(date2);
+    }
+  });
+
+  // Test for the "empty database for a source" scenario is implicitly covered by "source has no questions"
+  // The test for "empty array if no questions exist overall" is more complex with source filtering.
+  // The most direct test for an empty array is providing a source that yields no results.
+});
+

--- a/app/schemas/v1/answer.ts
+++ b/app/schemas/v1/answer.ts
@@ -1,4 +1,5 @@
 import bs58 from "bs58";
+import Decimal from "decimal.js";
 import { z } from "zod";
 
 const SolanaAddressSchema = z.string().refine(
@@ -23,6 +24,6 @@ export const AnswerSchema = z.object({
     .number()
     .min(0)
     .max(1)
-    .transform((v) => Math.round((v * 100) / 100)),
+    .transform((v) => Math.round(new Decimal(v).mul(100).toNumber())),
   weight: z.coerce.number().min(0).optional(),
 });

--- a/app/schemas/v1/update.ts
+++ b/app/schemas/v1/update.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 const QuestionIdSchema = z.string().uuid();
 
 export const UpdateQuestionSchema = z.object({
-  resolvesAt: z.coerce.date().optional().nullable(),
+  resolveAt: z.coerce.date().optional().nullable(),
 });
 
 export const UpdateQuestionParamsSchema = z.object({

--- a/lib/v1/getQuestions.ts
+++ b/lib/v1/getQuestions.ts
@@ -1,0 +1,41 @@
+import prisma from "@/app/services/prisma";
+import "server-only";
+
+export interface QuestionInfo {
+  questionId: string;
+  title: string;
+  description: string | null;
+  activeAt: Date | null;
+  resolveAt: Date | null;
+}
+
+/**
+ * Get Questions
+ * Return an array with basic information about each question matching the provided source.
+ * For more details, query questions individually through get question endpoint.
+ */
+export async function getQuestions(source: string): Promise<QuestionInfo[]> {
+  const questions = await prisma.question.findMany({
+    where: {
+      source: source, // Filter by source
+    },
+    select: {
+      uuid: true,
+      question: true,
+      description: true,
+      activeFromDate: true,
+      revealAtDate: true,
+    },
+    orderBy: {
+      activeFromDate: "desc",
+    },
+  });
+
+  return questions.map((q) => ({
+    questionId: q.uuid,
+    title: q.question,
+    description: q.description,
+    activeAt: q.activeFromDate,
+    resolveAt: q.revealAtDate,
+  }));
+}

--- a/lib/v1/updateQuestion.ts
+++ b/lib/v1/updateQuestion.ts
@@ -22,34 +22,34 @@ export async function updateQuestion(
     throw new ApiQuestionInvalidError("There is no question with that ID");
   }
 
-  if (update.resolvesAt && new Date(update.resolvesAt) <= now) {
-    throw new ApiQuestionInvalidError("resolvesAt must be in the future");
+  if (update.resolveAt && new Date(update.resolveAt) <= now) {
+    throw new ApiQuestionInvalidError("resolveAt must be in the future");
   }
 
   if (
-    update.resolvesAt &&
+    update.resolveAt &&
     question.activeFromDate &&
-    new Date(update.resolvesAt) <= new Date(question.activeFromDate)
+    new Date(update.resolveAt) <= new Date(question.activeFromDate)
   ) {
-    throw new ApiQuestionInvalidError("resolvesAt must be after activeDate");
+    throw new ApiQuestionInvalidError("resolveAt must be after activeDate");
   }
 
   // Nothing to do if value omitted
-  if (update.resolvesAt === undefined) return;
+  if (update.resolveAt === undefined) return;
 
   const rv = await prisma.question.updateMany({
     data: {
-      revealAtDate: update.resolvesAt,
+      revealAtDate: update.resolveAt,
     },
     where: {
       id: question.id,
       // Enforced again here to protect against race
-      ...(update.resolvesAt !== null
+      ...(update.resolveAt !== null
         ? {
             OR: [
               {
                 activeFromDate: {
-                  lt: update.resolvesAt,
+                  lt: update.resolveAt,
                 },
               },
               { activeFromDate: null },


### PR DESCRIPTION
- Add GET route to existing /v1/questions API route
- Only return desired subset of question info
- Also updates answer endpoint so that it accepts decimal values