### PR TITLE
fix: API fixes

### DIFF
--- a/__tests__/lib/v1/answerQuestion.test.ts
+++ b/__tests__/lib/v1/answerQuestion.test.ts
@@ -263,7 +263,41 @@ describe("answerQuestion", () => {
         1.0,
       ),
     ).rejects.toThrowError(
-      "User already submitted an answer for this question",
+      "User already submitted an answer for this question"
+    );
+  });
+
+  it("should throw error if first and second order options mismatch for binary question", async () => {
+    // Ensure the question is active
+    await prisma.question.update({
+      data: {
+        activeFromDate: pastDate,
+      },
+      where: {
+        // Use a question that is confirmed to be BinaryQuestion type
+        // questionUuids[0] is created with QuestionType.BinaryQuestion
+        id: questionIds[0],
+      },
+    });
+
+    // Ensure question0OptionUuids has at least two different options
+    if (question0OptionUuids.length < 2) {
+      // This should not happen based on current setup, but as a safeguard:
+      throw new Error("Test setup error: Need at least two distinct options for question 0 to test mismatch.");
+    }
+
+    await expect(
+      answerQuestion(
+        uuidv4(),
+        questionUuids[0], // This is a binary question
+        "mustard",
+        question0OptionUuids[0], // First option
+        question0OptionUuids[1], // Different second option
+        55, // secondOrderEstimate, value doesn't matter for this test
+        1.0, // weight, value doesn't matter for this test
+      ),
+    ).rejects.toThrowError(
+      "For binary questions, the second order option must be the same as the first order option",
     );
   });
 });

--- a/__tests__/v1/questions/answer.route.test.ts
+++ b/__tests__/v1/questions/answer.route.test.ts
@@ -293,7 +293,7 @@ describe("API answer question", () => {
         userAddress: user1.wallet,
         source: "crocodile",
         firstOrderOptionId: question1OptionUuids[0],
-        secondOrderOptionId: question1OptionUuids[1],
+        secondOrderOptionId: question1OptionUuids[0],
         secondOrderOptionEstimate: 0.5,
         weight: 1.0,
       }),
@@ -330,7 +330,7 @@ describe("API answer question", () => {
     );
     expect(firstOrderAnswer).toBeDefined();
     expect(firstOrderAnswer?.selected).toBe(true);
-    expect(firstOrderAnswer?.percentage).toBeNull();
+    expect(firstOrderAnswer?.percentage).toBe(50);
 
     // Find the answer for the second order option (this is where the percentage is set)
     const secondOrderAnswer = qAnswers.find(
@@ -338,7 +338,7 @@ describe("API answer question", () => {
     );
     expect(secondOrderAnswer).toBeDefined();
     expect(secondOrderAnswer?.selected).toBe(false);
-    expect(secondOrderAnswer?.percentage).toBe(50);
+    expect(secondOrderAnswer?.percentage).toBeNull();
 
     // Verify other answers for the same batch if necessary (e.g. for multi-choice)
     const questionOptionsForQuestion1 = await prisma.questionOption.count({
@@ -353,7 +353,7 @@ describe("API answer question", () => {
         userAddress: user1.wallet,
         source: "crocodile",
         firstOrderOptionId: question1OptionUuids[0],
-        secondOrderOptionId: question1OptionUuids[1],
+        secondOrderOptionId: question1OptionUuids[0],
         secondOrderOptionEstimate: 0.75,
         weight: 1.0,
       }),

--- a/app/v1/questions/[id]/route.ts
+++ b/app/v1/questions/[id]/route.ts
@@ -56,13 +56,13 @@ export async function GET(
       select: {
         id: true,
         uuid: true,
-        isCorrect: true,
+        calculatedIsCorrect: true,
         score: true,
         option: true,
       },
     });
 
-    const correctAnswer = questionOptions.find((option) => option.isCorrect);
+    const correctAnswer = questionOptions.find((option) => option.calculatedIsCorrect);
 
     const questionAnswers = await prisma.questionAnswer.findMany({
       where: {

--- a/lib/v1/answerQuestion.ts
+++ b/lib/v1/answerQuestion.ts
@@ -8,6 +8,7 @@ import {
   ApiQuestionInactiveError,
   ApiQuestionInvalidError,
 } from "../error";
+import { QuestionType } from "@prisma/client";
 
 export async function answerQuestion(
   userId: string,
@@ -75,6 +76,12 @@ export async function answerQuestion(
 
   if (!secondOrder)
     throw new ApiOptionInvalidError("Second order option not valid");
+
+  const isBinary = question.type === QuestionType.BinaryQuestion;
+  const is2ndOrderMismatch = firstOrderOptionId !== secondOrderOptionId;
+  if (isBinary && is2ndOrderMismatch) {
+    throw new ApiOptionInvalidError("For binary questions, the second order option must be the same as the first order option");
+  }
 
   const uuid = uuidv4();
 

--- a/lib/v1/transforQuestionAnswers.ts
+++ b/lib/v1/transforQuestionAnswers.ts
@@ -25,7 +25,7 @@ export function transformQuestionAnswers(questionAnswers: QuestionAnswer[]) {
         if (ua.selected) {
           answer.firstOrderOptionId = ua.questionOption.uuid;
           answer.answerId = ua.uuid;
-          answer.score = ua.score;
+          answer.answerScore = ua.score;
         }
         if (ua.percentage !== null) {
           answer.secondOrderOptionId = ua.questionOption.uuid;


### PR DESCRIPTION
https://linear.app/gator/issue/PROD-1123/api-enforce-binary-1st-order-=-2nd-order
https://linear.app/gator/issue/PROD-1118/api-get-question-results-should-return-scores

- Restrict 2nd order option for binary
- Return answerScores and bestOption