### PR TITLE
fix(PROD-126): retry rewards page failures

### DIFF
--- a/lib/error.ts
+++ b/lib/error.ts
@@ -288,3 +288,12 @@ export class ApiQuestionInactiveError extends ApiError {
     super(message);
   }
 }
+
+export class RewardsPromiseError extends Error {
+  name = "RewardsPromiseError";
+  error = "rewards_page_promise_error";
+
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+  }
+}


### PR DESCRIPTION
https://linear.app/gator/issue/PROD-126/error-an-error-occurred-in-the-server-components-render-the-specific

Based on the Sentry error, it seems most likely that one of the promises is failing and causing the whole page to crash. We know we experience timeouts and db connection starvation occasionally, which may be the source of intermittent failures.

This PR:
1. introduces retries to these requests
2. sends more granular error message to sentry so we can identify the root cause