### PR TITLE
fix: disable accidental question hopping

### DIFF
--- a/app/components/Deck/Deck.tsx
+++ b/app/components/Deck/Deck.tsx
@@ -40,6 +40,7 @@ import {
   AlertDialogTitle,
 } from "../ui/alert-dialog";
 import { Button } from "../ui/button";
+import { useDynamicContext } from "@dynamic-labs/sdk-react-core";
 
 export type Option = {
   id: number;
@@ -85,6 +86,8 @@ export function Deck({
   creditCostFeatureFlag,
   totalCredits,
 }: DeckProps) {
+  const { user } = useDynamicContext();
+ 
   const questionsRef = useRef<HTMLDivElement>(null);
   const [dueAt, setDueAt] = useState<Date>(getDueAt(questions, 0));
   const [deckResponse, setDeckResponse] = useState<SaveQuestionRequest[]>([]);
@@ -106,6 +109,7 @@ export function Deck({
   const [numberOfAnsweredQuestions, setNumberOfAnsweredQuestions] = useState(0);
   const [isCreditsLow, setIsCreditsLow] = useState(false);
   const [random, setRandom] = useState(0);
+
 
   useEffect(() => {
     start();
@@ -174,6 +178,7 @@ export function Deck({
                 deckId: deckId,
                 deckVariant: deckVariant,
                 currentQuestionIndex,
+                userId: user?.userId,
               },
             },
           );
@@ -186,6 +191,7 @@ export function Deck({
         }
       } catch (error) {
         console.error("Error marking question as seen:", error);
+        // Note: This has a different error message than the other captureMessage above. We can differentiate
         Sentry.captureMessage(
           `Caught exception when calling markQuestionAsSeenButNotAnswered. `,
           {
@@ -199,6 +205,7 @@ export function Deck({
               deckVariant: deckVariant,
               currentQuestionIndex,
               error: error,
+              userId: user?.userId,
             },
           },
         );


### PR DESCRIPTION
https://linear.app/gator/issue/PROD-1130/investigate-random-question-skipping-bug-on-decks-reported-by-user

We used to move to next question if problem marking question as seen. This led to a bug where we would skip questions if there was an error. We removed that, so now users may potentially see the same question again.      

Replaces https://github.com/gator-labs/chomp/pull/1182/files which had changes trying to address the root cause. But surface area of changes is too big.