### PR TITLE
PROD-1142: Create aggregate user balance table

### DIFF
--- a/__tests__/actions/answer/answer-binary.test.ts
+++ b/__tests__/actions/answer/answer-binary.test.ts
@@ -97,6 +97,12 @@ describe("answer binary question", () => {
       },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: userId,
+      },
+    });
+
     await prisma.user.delete({
       where: {
         id: userId,

--- a/__tests__/actions/answer/answer-credit.test.ts
+++ b/__tests__/actions/answer/answer-credit.test.ts
@@ -121,6 +121,12 @@ describe("Validate points logs for completing questions and decks", () => {
       },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: { in: [userId, authorId] },
+      },
+    });
+
     await prisma.user.deleteMany({
       where: {
         id: { in: [userId, authorId] },

--- a/__tests__/actions/answer/answer.test.ts
+++ b/__tests__/actions/answer/answer.test.ts
@@ -120,6 +120,12 @@ describe("Validate points logs for completing questions and decks", () => {
       },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: { in: [userId, authorId] },
+      },
+    });
+
     await prisma.user.deleteMany({
       where: {
         id: { in: [userId, authorId] },

--- a/__tests__/actions/answer/markQuestionAsSeenButNotAnswered.test.ts
+++ b/__tests__/actions/answer/markQuestionAsSeenButNotAnswered.test.ts
@@ -138,6 +138,9 @@ describe("markQuestionAsSeenButNotAnswered", () => {
     await prisma.fungibleAssetTransactionLog.deleteMany({
       where: { userId },
     });
+    await prisma.userBalance.deleteMany({
+      where: { userId },
+    });
     await prisma.questionAnswer.deleteMany({
       where: { userId },
     });

--- a/__tests__/actions/credits/updateTxStatusConfirm.test.ts
+++ b/__tests__/actions/credits/updateTxStatusConfirm.test.ts
@@ -98,6 +98,9 @@ describe("updateTxStatusToConfirmed", () => {
         },
       },
     });
+    await prisma.userBalance.deleteMany({
+      where: { userId: user.id },
+    });
     await prisma.chainTx.deleteMany({
       where: { wallet: user.wallet },
     });

--- a/__tests__/actions/get_alltime-leaderboard.test.ts
+++ b/__tests__/actions/get_alltime-leaderboard.test.ts
@@ -163,6 +163,13 @@ describe("Get All-time leaderboard data", () => {
         },
       },
     });
+
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: { in: users.map((user) => user.id) },
+      },
+    });
+
     await deleteDeck(deckId);
 
     await prisma.user.deleteMany({

--- a/__tests__/actions/leaderboard.test.ts
+++ b/__tests__/actions/leaderboard.test.ts
@@ -194,6 +194,11 @@ async function cleanupDatabase() {
       ],
     },
   });
+  await prisma.userBalance.deleteMany({
+    where: {
+      userId: { in: createdUserIds },
+    },
+  });
   // MysteryBoxTrigger can also be linked to deckId (not currently tracked for cleanup, but good to note)
   // Re-check dependencies: MysteryBoxTrigger is deleted above. Questions are deleted below.
   await prisma.question.deleteMany({

--- a/__tests__/actions/mystery-box.test.ts
+++ b/__tests__/actions/mystery-box.test.ts
@@ -183,6 +183,9 @@ describe("Create mystery box", () => {
     await prisma.fungibleAssetTransactionLog.deleteMany({
       where: { userId: user0.id },
     });
+    await prisma.userBalance.deleteMany({
+      where: { userId: user0.id },
+    });
 
     await deleteDeck(deckId);
 

--- a/__tests__/actions/open-mystery-box-hub.test.ts
+++ b/__tests__/actions/open-mystery-box-hub.test.ts
@@ -149,6 +149,14 @@ describe("openMysteryBoxHub", () => {
       },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: {
+          in: [user.id, user1.id],
+        },
+      },
+    });
+
     const trigger = mysteryBox.flatMap((mb) => mb.triggers);
 
     await prisma.mysteryBoxPrize.deleteMany({

--- a/__tests__/api/process-credits/route.test.ts
+++ b/__tests__/api/process-credits/route.test.ts
@@ -119,6 +119,12 @@ describe("GET /api/cron/process-credits", () => {
       },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: { in: [users[0].id, users[1].id, users[2].id] },
+      },
+    });
+
     await prisma.chainTx.deleteMany({
       where: {
         hash: { in: [validTxHash, validTxHash2, invalidTxHash] },

--- a/__tests__/db/triggers/ask-points.test.ts
+++ b/__tests__/db/triggers/ask-points.test.ts
@@ -136,6 +136,12 @@ describe("Ask DB triggers", () => {
         },
       });
 
+      await prisma.userBalance.deleteMany({
+        where: {
+          userId: { in: users.map((u) => u.id) },
+        },
+      });
+
       await prisma.user.deleteMany({
         where: { id: { in: users.map((u) => u.id) } },
       });

--- a/__tests__/db/triggers/user-balance.test.ts
+++ b/__tests__/db/triggers/user-balance.test.ts
@@ -2,10 +2,7 @@ import prisma from "@/app/services/prisma";
 import { getCreditBalance } from "@/lib/credits/getCreditBalance";
 import { getPointBalance } from "@/lib/points/getPointBalance";
 import { generateUsers } from "@/scripts/utils";
-import {
-  FungibleAsset,
-  TransactionLogType,
-} from "@prisma/client";
+import { FungibleAsset, TransactionLogType } from "@prisma/client";
 
 describe("User balance trigger", () => {
   let users: { id: string; username: string }[];

--- a/__tests__/db/triggers/user-balance.test.ts
+++ b/__tests__/db/triggers/user-balance.test.ts
@@ -1,0 +1,113 @@
+import prisma from "@/app/services/prisma";
+import { getCreditBalance } from "@/lib/credits/getCreditBalance";
+import { getPointBalance } from "@/lib/points/getPointBalance";
+import { generateUsers } from "@/scripts/utils";
+import {
+  ESpecialStack,
+  FungibleAsset,
+  TransactionLogType,
+} from "@prisma/client";
+
+describe("User balance trigger", () => {
+  let deck: { id: number };
+  const questions: { id: number }[] = [];
+  let communityDeck: { id: number };
+  let origCommunityStack: { id: number } | null;
+  let users: { id: string; username: string }[];
+
+  beforeAll(async () => {
+    users = await generateUsers(2);
+
+    await prisma.user.createMany({
+      data: users,
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.fungibleAssetTransactionLog.deleteMany({
+      where: { userId: { in: users.map((q) => q.id) } },
+    });
+    await prisma.userBalance.deleteMany({
+      where: { userId: { in: users.map((u) => u.id) } },
+    });
+    await prisma.user.deleteMany({
+      where: { id: { in: users.map((u) => u.id) } },
+    });
+  });
+
+  it("should update user balance table", async () => {
+    const pointsBalanceBefore = await getPointBalance(users[0].id);
+    const creditsBalanceBefore = await getCreditBalance(users[0].id);
+
+    await prisma.fungibleAssetTransactionLog.createMany({
+      data: [
+        {
+          userId: users[0].id,
+          asset: FungibleAsset.Point,
+          change: 4,
+          type: TransactionLogType.CreditByAdmin,
+        },
+        {
+          userId: users[0].id,
+          asset: FungibleAsset.Point,
+          change: -2,
+          type: TransactionLogType.CreditByAdmin,
+        },
+        {
+          userId: users[0].id,
+          asset: FungibleAsset.Point,
+          change: 1.5,
+          type: TransactionLogType.CreditByAdmin,
+        },
+        {
+          userId: users[0].id,
+          asset: FungibleAsset.Credit,
+          change: 66,
+          type: TransactionLogType.CreditByAdmin,
+        },
+      ],
+    });
+
+    const pointsBalanceAfter = await getPointBalance(users[0].id);
+    const creditsBalanceAfter = await getCreditBalance(users[0].id);
+
+    expect(pointsBalanceAfter - pointsBalanceBefore).toEqual(3.5);
+    expect(creditsBalanceAfter - creditsBalanceBefore).toEqual(66);
+  });
+
+  it("should update user balance table (2)", async () => {
+    const pointsBalanceBefore = await getPointBalance(users[1].id);
+    const creditsBalanceBefore = await getCreditBalance(users[1].id);
+
+    await prisma.fungibleAssetTransactionLog.createMany({
+      data: [
+        {
+          userId: users[1].id,
+          asset: FungibleAsset.Point,
+          change: 11,
+          type: TransactionLogType.CreditByAdmin,
+        },
+        {
+          userId: users[1].id,
+          asset: FungibleAsset.Credit,
+          change: 44,
+          type: TransactionLogType.CreditByAdmin,
+        },
+      ],
+    });
+
+    const pointsBalanceAfter = await getPointBalance(users[1].id);
+    const creditsBalanceAfter = await getCreditBalance(users[1].id);
+
+    expect(pointsBalanceAfter - pointsBalanceBefore).toEqual(11);
+    expect(creditsBalanceAfter - creditsBalanceBefore).toEqual(44);
+
+    // Check user0 wasn't affected
+
+    const user0pointsBalance = await getPointBalance(users[0].id);
+    const user0creditsBalance = await getCreditBalance(users[0].id);
+
+    expect(user0pointsBalance).toEqual(3.5);
+    expect(user0creditsBalance).toEqual(66);
+  });
+});

--- a/__tests__/db/triggers/user-balance.test.ts
+++ b/__tests__/db/triggers/user-balance.test.ts
@@ -3,16 +3,11 @@ import { getCreditBalance } from "@/lib/credits/getCreditBalance";
 import { getPointBalance } from "@/lib/points/getPointBalance";
 import { generateUsers } from "@/scripts/utils";
 import {
-  ESpecialStack,
   FungibleAsset,
   TransactionLogType,
 } from "@prisma/client";
 
 describe("User balance trigger", () => {
-  let deck: { id: number };
-  const questions: { id: number }[] = [];
-  let communityDeck: { id: number };
-  let origCommunityStack: { id: number } | null;
   let users: { id: string; username: string }[];
 
   beforeAll(async () => {

--- a/__tests__/lib/ask/addToCommunityAskList.test.ts
+++ b/__tests__/lib/ask/addToCommunityAskList.test.ts
@@ -120,6 +120,12 @@ describe("Add to community ask list", () => {
         },
       });
 
+      await prisma.userBalance.deleteMany({
+        where: {
+          userId: { in: users.map((u) => u.id) },
+        },
+      });
+
       await prisma.user.deleteMany({
         where: { id: { in: users.map((u) => u.id) } },
       });

--- a/__tests__/lib/credits/chargeUserCredits.test.ts
+++ b/__tests__/lib/credits/chargeUserCredits.test.ts
@@ -110,6 +110,11 @@ describe("chargeUserCredits", () => {
     await prisma.fungibleAssetTransactionLog.deleteMany({
       where: { userId: mockUserId },
     });
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: mockUserId,
+      },
+    });
     await prisma.questionAnswer.deleteMany({
       where: {
         questionOptionId: {

--- a/__tests__/lib/mysteryBox/get-breakdown.test.ts
+++ b/__tests__/lib/mysteryBox/get-breakdown.test.ts
@@ -206,6 +206,10 @@ describe("Create mystery box", () => {
       where: { userId: user0.id },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: { userId: user0.id },
+    });
+
     await deleteDeck(deckId);
 
     await deleteMysteryBoxes(

--- a/__tests__/queries/get-validation-reward-question.test.ts
+++ b/__tests__/queries/get-validation-reward-question.test.ts
@@ -146,6 +146,12 @@ describe("getValidationRewardQuestion", () => {
       },
     });
 
+    await prisma.userBalance.deleteMany({
+      where: {
+        userId: { in: [userId, userId1, userId2] },
+      },
+    });
+
     await prisma.user.deleteMany({
       where: {
         id: { in: [userId, userId1, userId2] },

--- a/__tests__/queries/home/get-total-claimed-credit.test.ts
+++ b/__tests__/queries/home/get-total-claimed-credit.test.ts
@@ -128,6 +128,9 @@ describe("getUserTotalCreditAmount", () => {
     await prisma.fungibleAssetTransactionLog.deleteMany({
       where: { userId: user1.id },
     });
+    await prisma.userBalance.deleteMany({
+      where: { userId: user1.id },
+    });
     await deleteMysteryBoxes([mysteryBox1, mysteryBox2]);
     await prisma.user.delete({
       where: {

--- a/__tests__/queries/home/get-total-claimed-points.test.ts
+++ b/__tests__/queries/home/get-total-claimed-points.test.ts
@@ -56,6 +56,11 @@ describe("getUserTotalPoints", () => {
       await prisma.fungibleAssetTransactionLog.deleteMany({
         where: { userId: user1.id },
       });
+      await prisma.userBalance.deleteMany({
+        where: {
+          userId: user1.id,
+        },
+      });
       await prisma.user.delete({
         where: {
           id: user1.id,

--- a/__tests__/queries/home/streak.test.ts
+++ b/__tests__/queries/home/streak.test.ts
@@ -390,6 +390,11 @@ describe("getUsersLatestStreak", () => {
           userId: { in: [user1.id, user2.id, user3.id] },
         },
       });
+      await prisma.userBalance.deleteMany({
+        where: {
+          userId: { in: [user1.id, user2.id, user3.id] },
+        },
+      });
       await tx.mysteryBox.deleteMany({
         where: {
           userId: { in: [user1.id, user2.id, user3.id] },

--- a/lib/credits/getCreditBalance.ts
+++ b/lib/credits/getCreditBalance.ts
@@ -3,17 +3,14 @@ import { FungibleAsset } from "@prisma/client";
 import "server-only";
 
 export async function getCreditBalance(userId: string) {
-  const res = await prisma.fungibleAssetTransactionLog.aggregate({
+  const res = await prisma.userBalance.findUnique({
     where: {
-      asset: FungibleAsset.Credit,
-      userId,
-    },
-    _sum: {
-      change: true,
+      userId_asset: {
+        asset: FungibleAsset.Credit,
+        userId,
+      },
     },
   });
 
-  if (!res?._sum?.change) return 0;
-
-  return res._sum.change.toNumber();
+  return res?.balance.toNumber() ?? 0;
 }

--- a/lib/points/getPointBalance.ts
+++ b/lib/points/getPointBalance.ts
@@ -2,7 +2,7 @@ import prisma from "@/app/services/prisma";
 import { FungibleAsset } from "@prisma/client";
 import "server-only";
 
-export async function getCreditBalance(userId: string) {
+export async function getPointBalance(userId: string) {
   const res = await prisma.userBalance.findUnique({
     where: {
       userId_asset: {

--- a/lib/points/getPointBalance.ts
+++ b/lib/points/getPointBalance.ts
@@ -2,18 +2,15 @@ import prisma from "@/app/services/prisma";
 import { FungibleAsset } from "@prisma/client";
 import "server-only";
 
-export async function getPointBalance(userId: string) {
-  const res = await prisma.fungibleAssetTransactionLog.aggregate({
+export async function getCreditBalance(userId: string) {
+  const res = await prisma.userBalance.findUnique({
     where: {
-      asset: FungibleAsset.Point,
-      userId,
-    },
-    _sum: {
-      change: true,
+      userId_asset: {
+        asset: FungibleAsset.Point,
+        userId,
+      },
     },
   });
 
-  if (!res?._sum?.change) return 0;
-
-  return res._sum.change.toNumber();
+  return res?.balance.toNumber() ?? 0;
 }

--- a/prisma/migrations/20250601170000_add_userbalance_view/migration.sql
+++ b/prisma/migrations/20250601170000_add_userbalance_view/migration.sql
@@ -1,9 +1,0 @@
-CREATE MATERIALIZED VIEW "UserBalance" AS
-SELECT
-    SUM("change") AS "balance",
-    "asset",
-    "userId"
-    FROM "FungibleAssetTransactionLog"
-    GROUP BY ("userId", "asset");
-
-CREATE INDEX "UserBalance_userId_asset" ON "UserBalance" ("userId", "asset");

--- a/prisma/migrations/20250601170000_add_userbalance_view/migration.sql
+++ b/prisma/migrations/20250601170000_add_userbalance_view/migration.sql
@@ -1,0 +1,9 @@
+CREATE MATERIALIZED VIEW "UserBalance" AS
+SELECT
+    SUM("change") AS "balance",
+    "asset",
+    "userId"
+    FROM "FungibleAssetTransactionLog"
+    GROUP BY ("userId", "asset");
+
+CREATE INDEX "UserBalance_userId_asset" ON "UserBalance" ("userId", "asset");

--- a/prisma/migrations/20250604124636_add_userbalance_table/migration.sql
+++ b/prisma/migrations/20250604124636_add_userbalance_table/migration.sql
@@ -10,3 +10,11 @@ CREATE UNIQUE INDEX "UserBalance_userId_asset_key" ON "UserBalance"("userId", "a
 
 -- AddForeignKey
 ALTER TABLE "UserBalance" ADD CONSTRAINT "UserBalance_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+INSERT INTO "UserBalance" ("userId", "asset", "balance")
+SELECT
+    "userId",
+    asset,
+    SUM(change)
+FROM "FungibleAssetTransactionLog"
+GROUP BY "userId", asset;

--- a/prisma/migrations/20250604124636_add_userbalance_table/migration.sql
+++ b/prisma/migrations/20250604124636_add_userbalance_table/migration.sql
@@ -1,0 +1,12 @@
+-- CreateTable
+CREATE TABLE "UserBalance" (
+    "userId" TEXT NOT NULL,
+    "asset" "FungibleAsset" NOT NULL,
+    "balance" DECIMAL(65,30) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserBalance_userId_asset_key" ON "UserBalance"("userId", "asset");
+
+-- AddForeignKey
+ALTER TABLE "UserBalance" ADD CONSTRAINT "UserBalance_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20250604170000_add_userbalance_trigger/migration.sql
+++ b/prisma/migrations/20250604170000_add_userbalance_trigger/migration.sql
@@ -2,33 +2,33 @@ CREATE OR REPLACE FUNCTION sync_user_balance()
 RETURNS trigger AS $$
 BEGIN
   IF (TG_OP = 'INSERT') THEN
-    INSERT INTO "UserBalance" ("userId", asset, balance)
+    INSERT INTO public."UserBalance" ("userId", asset, balance)
     VALUES (NEW."userId", NEW.asset, NEW.change)
     ON CONFLICT ("userId", asset)
-    DO UPDATE SET balance = "UserBalance".balance + EXCLUDED.balance;
+    DO UPDATE SET balance = public."UserBalance".balance + EXCLUDED.balance;
 
   ELSIF (TG_OP = 'DELETE') THEN
-    UPDATE "UserBalance"
+    UPDATE public."UserBalance"
     SET balance = balance - OLD.change
     WHERE "userId" = OLD."userId" AND asset = OLD.asset;
 
   ELSIF (TG_OP = 'UPDATE') THEN
     IF (OLD."userId" = NEW."userId" AND OLD.asset = NEW.asset) THEN
       -- Straight update to FATL entry: need to sync the net change
-      UPDATE "UserBalance"
+      UPDATE public."UserBalance"
       SET balance = balance + (NEW.change - OLD.change)
       WHERE "userId" = NEW."userId" AND asset = NEW.asset;
     ELSE
       -- FATL entry userId or asset changing: both records
       -- must be updated in this case
-      UPDATE "UserBalance"
+      UPDATE public."UserBalance"
       SET balance = balance - OLD.change
       WHERE "userId" = OLD."userId" AND asset = OLD.asset;
 
-      INSERT INTO "UserBalance" ("userId", asset, balance)
+      INSERT INTO public."UserBalance" ("userId", asset, balance)
       VALUES (NEW."userId", NEW.asset, NEW.change)
       ON CONFLICT ("userId", asset)
-      DO UPDATE SET balance = "UserBalance".balance + EXCLUDED.balance;
+      DO UPDATE SET balance = public."UserBalance".balance + EXCLUDED.balance;
     END IF;
   END IF;
 
@@ -37,5 +37,5 @@ END;
 $$ LANGUAGE plpgsql;
 
 CREATE TRIGGER trigger_sync_user_balance
-AFTER INSERT OR UPDATE OR DELETE ON "FungibleAssetTransactionLog"
+AFTER INSERT OR UPDATE OR DELETE ON public."FungibleAssetTransactionLog"
 FOR EACH ROW EXECUTE FUNCTION sync_user_balance();

--- a/prisma/migrations/20250604170000_add_userbalance_trigger/migration.sql
+++ b/prisma/migrations/20250604170000_add_userbalance_trigger/migration.sql
@@ -1,0 +1,41 @@
+CREATE OR REPLACE FUNCTION sync_user_balance()
+RETURNS trigger AS $$
+BEGIN
+  IF (TG_OP = 'INSERT') THEN
+    INSERT INTO "UserBalance" ("userId", asset, balance)
+    VALUES (NEW."userId", NEW.asset, NEW.change)
+    ON CONFLICT ("userId", asset)
+    DO UPDATE SET balance = "UserBalance".balance + EXCLUDED.balance;
+
+  ELSIF (TG_OP = 'DELETE') THEN
+    UPDATE "UserBalance"
+    SET balance = balance - OLD.change
+    WHERE "userId" = OLD."userId" AND asset = OLD.asset;
+
+  ELSIF (TG_OP = 'UPDATE') THEN
+    IF (OLD."userId" = NEW."userId" AND OLD.asset = NEW.asset) THEN
+      -- Straight update to FATL entry: need to sync the net change
+      UPDATE "UserBalance"
+      SET balance = balance + (NEW.change - OLD.change)
+      WHERE "userId" = NEW."userId" AND asset = NEW.asset;
+    ELSE
+      -- FATL entry userId or asset changing: both records
+      -- must be updated in this case
+      UPDATE "UserBalance"
+      SET balance = balance - OLD.change
+      WHERE "userId" = OLD."userId" AND asset = OLD.asset;
+
+      INSERT INTO "UserBalance" ("userId", asset, balance)
+      VALUES (NEW."userId", NEW.asset, NEW.change)
+      ON CONFLICT ("userId", asset)
+      DO UPDATE SET balance = "UserBalance".balance + EXCLUDED.balance;
+    END IF;
+  END IF;
+
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_sync_user_balance
+AFTER INSERT OR UPDATE OR DELETE ON "FungibleAssetTransactionLog"
+FOR EACH ROW EXECUTE FUNCTION sync_user_balance();

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,6 +40,7 @@ model User {
   Question                 Question[]
   AskQuestionAnswer        AskQuestionAnswer[]
   UserQuestionAnswerStatus UserQuestionAnswerStatus[]
+  UserBalance              UserBalance[]
 }
 
 model Wallet {
@@ -465,6 +466,15 @@ view UserQuestionAnswerStatus {
 
   questionId Int      @id
   question   Question @relation(fields: [questionId], references: [id])
+}
+
+view UserBalance {
+  userId String
+  user   User          @relation(fields: [userId], references: [id])
+  asset  FungibleAsset
+  change Decimal
+
+  @@unique([userId, asset])
 }
 
 enum ESpecialStack {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -436,6 +436,15 @@ model CreditPack {
   createdAt                   DateTime                      @default(now())
 }
 
+model UserBalance {
+  userId  String
+  user    User          @relation(fields: [userId], references: [id])
+  asset   FungibleAsset
+  balance Decimal
+
+  @@unique([userId, asset])
+}
+
 view DeckRewards {
   bonkReward    String
   creditsReward String
@@ -466,15 +475,6 @@ view UserQuestionAnswerStatus {
 
   questionId Int      @id
   question   Question @relation(fields: [questionId], references: [id])
-}
-
-view UserBalance {
-  userId  String
-  user    User          @relation(fields: [userId], references: [id])
-  asset   FungibleAsset
-  balance Decimal
-
-  @@unique([userId, asset])
 }
 
 enum ESpecialStack {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -469,10 +469,10 @@ view UserQuestionAnswerStatus {
 }
 
 view UserBalance {
-  userId String
-  user   User          @relation(fields: [userId], references: [id])
-  asset  FungibleAsset
-  change Decimal
+  userId  String
+  user    User          @relation(fields: [userId], references: [id])
+  asset   FungibleAsset
+  balance Decimal
 
   @@unique([userId, asset])
 }


### PR DESCRIPTION
Add a user balance table to track actual user balances and avoid constant summing over the FATL.

I was initially going to go with a materialised view but I think this approach is more efficient.