### PR TITLE
fix(PROD-126): Server component render on rewards page

### DIFF
--- a/app/application/rewards/page.tsx
+++ b/app/application/rewards/page.tsx
@@ -1,4 +1,5 @@
 import ProfileNavigation from "@/app/components/ProfileNavigation/ProfileNavigation";
+import { getJwtPayload } from "@/app/actions/jwt";
 import { getValidationRewardQuestions } from "@/app/queries/getValidationRewardQuestion";
 import MysteryBoxHub from "@/components/MysteryBox/MysteryBoxHub";
 import { hasBonkAtaAccount } from "@/lib/bonk/hasBonkAtaAccount";
@@ -6,8 +7,15 @@ import { RewardsPromiseError } from "@/lib/error";
 import { getCampaigns } from "@/lib/mysteryBox/getCampaigns";
 import { captureException } from "@sentry/nextjs";
 import pRetry, { FailedAttemptError, Options as RetryOptions } from "p-retry";
+import { redirect } from "next/navigation";
 
 async function Page() {
+  // Check authentication first
+  const payload = await getJwtPayload();
+  if (!payload) {
+    redirect("/");
+  }
+
   const CREDIT_COST_FEATURE_FLAG =
     process.env.NEXT_PUBLIC_FF_CREDIT_COST_PER_QUESTION === "true";
 

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -14,10 +14,10 @@ Sentry.init({
   // Define how likely Replay events are sampled.
   // This sets the sample rate to be 10%. You may want this to be 100% while
   // in development and sample at a lower rate in production
-  replaysSessionSampleRate: 0.01,
+  replaysSessionSampleRate: 0.05,
 
   // Define how likely Replay events are sampled when an error occurs.
-  replaysOnErrorSampleRate: 0.01,
+  replaysOnErrorSampleRate: 0.05,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
https://linear.app/gator/issue/PROD-126/error-an-error-occurred-in-the-server-components-render-the-specific

- Core issue was that if user is not logged in, hasBonkAtaAccount, throws an exception. Now it returns false.
- Also added redirect at the page level to prompt the user to login
- Unrelated increase in replay captures also included in this PR